### PR TITLE
feat: add SSH tunnel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ The server requires the following environment variables:
 }
 ```
 
+### SSH tunnel (optional)
+
+If PostgreSQL is reachable only through an SSH bastion, configure the database host and port as the destination visible from that bastion, then add these variables to `env`:
+
+```json
+{
+  "SSH_HOST": "bastion.example.com",
+  "SSH_PORT": "22",
+  "SSH_USER": "deploy",
+  "SSH_PRIVATE_KEY_PATH": "/absolute/path/to/id_ed25519",
+  "SSH_HOST_FINGERPRINT": "SHA256:your-host-key-fingerprint"
+}
+```
+
+Authentication can use exactly one of `SSH_PRIVATE_KEY_PATH`, `SSH_PRIVATE_KEY`, or `SSH_PASSWORD`. For encrypted private keys, add `SSH_PRIVATE_KEY_PASSPHRASE`.
+
+`SSH_HOST_FINGERPRINT` is strongly recommended: it verifies the bastion's host key and prevents connecting to an unexpected server. The fingerprint is the SHA-256 value shown by `ssh-keygen -lf /path/to/known_hosts` (the optional `SHA256:` prefix is accepted). If it is omitted, the server logs a warning and connects without host-key verification for backwards-compatible setup.
+
 ## Available Tools
 
 ### 1. connect_db

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.6.0",
         "dotenv": "^16.4.7",
-        "pg": "^8.11.3"
+        "pg": "^8.11.3",
+        "ssh2": "^1.17.0"
       },
       "bin": {
         "mcp-postgres": "build/index.js"
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@types/node": "^20.11.24",
         "@types/pg": "^8.10.7",
+        "@types/ssh2": "^1.15.5",
         "typescript": "^5.3.3"
       }
     },
@@ -55,6 +57,60 @@
         "pg-types": "^4.0.1"
       }
     },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -71,6 +127,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/depd": {
@@ -128,6 +198,13 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -140,6 +217,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.14.1.tgz",
       "integrity": "sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.7.0",
         "pg-pool": "^3.8.0",
@@ -378,6 +456,23 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -395,6 +490,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/typescript": {
       "version": "5.8.2",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.6.0",
     "dotenv": "^16.4.7",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "ssh2": "^1.17.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",
     "@types/pg": "^8.10.7",
+    "@types/ssh2": "^1.15.5",
     "typescript": "^5.3.3"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import pg from 'pg';
 const { Client } = pg;
+import { Client as SshClient, type ConnectConfig, type ClientChannel } from 'ssh2';
 import { config } from 'dotenv';
+import { readFileSync } from 'node:fs';
 
 // Load environment variables
 config();
@@ -20,6 +22,16 @@ interface DatabaseConfig {
   user: string;
   password: string;
   database: string;
+}
+
+interface SshTunnelConfig {
+  host: string;
+  port: number;
+  username: string;
+  password?: string;
+  privateKey?: string;
+  passphrase?: string;
+  hostFingerprint?: string;
 }
 
 // Type guard for error objects
@@ -50,6 +62,8 @@ class PostgresServer {
   private server: Server;
   private client: pg.Client | null = null;
   private config: DatabaseConfig | null = null;
+  private sshClient: SshClient | null = null;
+  private sshConfig: SshTunnelConfig | null = null;
 
   constructor() {
     this.server = new Server(
@@ -84,6 +98,11 @@ class PostgresServer {
   private async cleanup() {
     if (this.client) {
       await this.client.end();
+      this.client = null;
+    }
+    if (this.sshClient) {
+      this.sshClient.end();
+      this.sshClient = null;
     }
     await this.server.close();
   }
@@ -95,6 +114,7 @@ class PostgresServer {
       
       if (envConfig) {
         this.config = envConfig;
+        this.sshConfig = this.getSshConfig();
         console.error('[MCP Info] Using database config from environment variables');
       } else {
         throw new McpError(
@@ -106,9 +126,16 @@ class PostgresServer {
 
     if (!this.client) {
       try {
-        this.client = new Client(this.config);
+        const stream = this.sshConfig
+          ? await this.createSshStream(this.config.host, this.config.port)
+          : undefined;
+        this.client = new Client({ ...this.config, ...(stream ? { stream: () => stream } : {}) });
         await this.client.connect();
       } catch (error) {
+        if (this.sshClient) {
+          this.sshClient.end();
+          this.sshClient = null;
+        }
         throw new McpError(
           ErrorCode.InternalError,
           `Failed to connect to database: ${getErrorMessage(error)}`
@@ -131,6 +158,95 @@ class PostgresServer {
     }
     
     return null;
+  }
+
+  private getSshConfig(): SshTunnelConfig | null {
+    const {
+      SSH_HOST,
+      SSH_PORT,
+      SSH_USER,
+      SSH_PASSWORD,
+      SSH_PRIVATE_KEY,
+      SSH_PRIVATE_KEY_PATH,
+      SSH_PRIVATE_KEY_PASSPHRASE,
+      SSH_HOST_FINGERPRINT,
+    } = process.env;
+
+    const hasSshConfiguration = [
+      SSH_HOST,
+      SSH_PORT,
+      SSH_USER,
+      SSH_PASSWORD,
+      SSH_PRIVATE_KEY,
+      SSH_PRIVATE_KEY_PATH,
+      SSH_PRIVATE_KEY_PASSPHRASE,
+      SSH_HOST_FINGERPRINT,
+    ].some(Boolean);
+    if (!hasSshConfiguration) {
+      return null;
+    }
+
+    if (!SSH_HOST || !SSH_USER) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        'SSH tunnel configuration requires both SSH_HOST and SSH_USER'
+      );
+    }
+
+    const port = SSH_PORT ? parseInt(SSH_PORT, 10) : 22;
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new McpError(ErrorCode.InvalidRequest, 'SSH_PORT must be a valid TCP port');
+    }
+
+    const privateKey = SSH_PRIVATE_KEY || (SSH_PRIVATE_KEY_PATH ? readFileSync(SSH_PRIVATE_KEY_PATH, 'utf8') : undefined);
+    if (!SSH_PASSWORD && !privateKey) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        'SSH tunnel configuration requires SSH_PASSWORD, SSH_PRIVATE_KEY, or SSH_PRIVATE_KEY_PATH'
+      );
+    }
+
+    return {
+      host: SSH_HOST,
+      port,
+      username: SSH_USER,
+      password: SSH_PASSWORD,
+      privateKey,
+      passphrase: SSH_PRIVATE_KEY_PASSPHRASE,
+      hostFingerprint: SSH_HOST_FINGERPRINT,
+    };
+  }
+
+  private async createSshStream(destinationHost: string, destinationPort: number): Promise<ClientChannel> {
+    if (!this.sshConfig) {
+      throw new Error('SSH tunnel configuration is not set');
+    }
+
+    const { host, port, username, password, privateKey, passphrase, hostFingerprint } = this.sshConfig;
+    const sshOptions: ConnectConfig = { host, port, username, password, privateKey, passphrase };
+    if (hostFingerprint) {
+      sshOptions.hostHash = 'sha256';
+      sshOptions.hostVerifier = (hash: string) => hash === hostFingerprint.replace(/^SHA256:/, '');
+    } else {
+      console.error('[MCP Warning] SSH_HOST_FINGERPRINT is not set; the SSH host key will not be verified');
+    }
+
+    this.sshClient = new SshClient();
+    await new Promise<void>((resolve, reject) => {
+      this.sshClient!.once('ready', resolve);
+      this.sshClient!.once('error', reject);
+      this.sshClient!.connect(sshOptions);
+    });
+
+    return new Promise<ClientChannel>((resolve, reject) => {
+      this.sshClient!.forwardOut('127.0.0.1', 0, destinationHost, destinationPort, (error, stream) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(stream);
+      });
+    });
   }
 
   private setupToolHandlers() {
@@ -283,10 +399,16 @@ class PostgresServer {
       );
     }
 
-    // Close existing connection if any
-    if (this.client) {
-      await this.client.end();
-      this.client = null;
+    // Close existing connection and SSH tunnel if any
+    if (this.client || this.sshClient) {
+      if (this.client) {
+        await this.client.end();
+        this.client = null;
+      }
+      if (this.sshClient) {
+        this.sshClient.end();
+        this.sshClient = null;
+      }
     }
 
     this.config = {
@@ -296,6 +418,7 @@ class PostgresServer {
       password: args.password,
       database: args.database,
     };
+    this.sshConfig = this.getSshConfig();
 
     try {
       await this.ensureConnection();


### PR DESCRIPTION
## Summary

Adds optional SSH tunneling for PostgreSQL connections, addressing #3.

- Routes the PostgreSQL client through an `ssh2` direct-tcpip channel; no local listening port is created.
- Supports SSH authentication with a private key (inline or path) or password.
- Supports optional SHA-256 SSH host-key fingerprint verification and warns when omitted.
- Closes both PostgreSQL and SSH resources on reconnect, failure, and shutdown.
- Documents all SSH environment variables and a bastion configuration example.

## Configuration

Set `SSH_HOST` and `SSH_USER`, plus exactly one of `SSH_PRIVATE_KEY_PATH`, `SSH_PRIVATE_KEY`, or `SSH_PASSWORD`. `SSH_HOST_FINGERPRINT` is strongly recommended.

## Validation

- `npm run build`
- `git diff --check`

Closes #3.
