### PR TITLE
feat!: read-only by default, SSH tunneling, and byte-capped query results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Full Node x Postgres sweep on the ends of both ranges, plus the
+        # current middle, without exploding into every combination.
+        node-version: [20, 22, 24]
+        postgres: ['13-alpine', '16-alpine', '17-alpine']
+        include:
+          - node-version: 24
+            postgres: '18-alpine'
+    services:
+      postgres:
+        image: postgres:${{ matrix.postgres }}
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: mcp_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm run coverage
+        env:
+          PG_TEST_URL: postgres://postgres:postgres@localhost:5432/mcp_test

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 node_modules/
 build/
+coverage/
 .env
+.env.*
 *.log
+*.tsbuildinfo
+*.tgz
 .DS_Store
 .idea/
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - Unreleased
+
+> **BREAKING (from 0.1.x):**
+>
+> 1. **Read-only by default.** Set `PG_ALLOW_WRITE=true` for writes; `execute` stays visible but refuses them until then.
+> 2. **`connect_db` requires `PG_ENABLE_RUNTIME_CONNECT=true`** (otherwise not registered).
+>
+> See "Migrating from 0.1.x" in the README.
+
+### Added
+
+- Engine-enforced read-only: reads run as `BEGIN READ ONLY` + the bound statement + `ROLLBACK`
+  (no client-side SQL parsing; PostgreSQL is the boundary). `execute` refuses writes unless
+  `PG_ALLOW_WRITE=true`.
+- Optional SSH tunneling (`PG_SSH_*`): reach the database through a bastion. Mandatory host-key
+  pinning (`PG_SSH_FINGERPRINT`, fail-closed); key / agent / password auth with `ssh`-style
+  fallback (`SSH_AUTH_SOCK`, `~/.ssh/id_ed25519`); TLS validated against the real hostname;
+  keepalive + lazy reconnect. `ssh2` is an optional dependency, loaded only when configured.
+- `DATABASE_URL` support (preferred over `PG_*`), plus `PG_SSLMODE`
+  (`disable`|`allow`|`prefer`|`require`|`verify-ca`|`verify-full`) and `PG_SSL_CA`. `allow`/`prefer`
+  do not fall back to plaintext; verifying modes pin `rejectUnauthorized`. Full pg options
+  (`application_name`, `options`/`search_path`) and IPv6 `[::1]` URLs handled for direct and tunneled
+  connections alike.
+- Result size cap (`PG_MAX_RESULT_BYTES`, default 32768): whole rows within the byte budget, else
+  `returnedRows < rowCount` + `truncated: true` + a refine hint.
+- Statement timeout (`PG_STATEMENT_TIMEOUT`, 30000 ms) and connect timeout (`PG_CONNECT_TIMEOUT`,
+  10000 ms).
+- SQLSTATE-based error hints; stderr warning when connected as a superuser in read-only mode.
+- MCP tool annotations per spec 2025-11-25 (`readOnlyHint`/`destructiveHint`/`openWorldHint`).
+- Test suite (unit + integration against a real Postgres + tool-surface snapshot) and CI on Node 20/22/24.
+
+### Changed
+
+- **BREAKING:** read-only by default; `query` now accepts `SELECT`/`WITH`/`EXPLAIN`/`SHOW`.
+- **BREAKING:** `connect_db` opt-in via `PG_ENABLE_RUNTIME_CONNECT=true`.
+- **BREAKING:** result payloads are compact JSON with new shapes:
+  - `query`: `{rows, rowCount, returnedRows, truncated}` (was a bare row array);
+  - `list_schemas`: `{schemas: [...]}`; `list_tables`: `{tables: [...]}`;
+  - `describe_table`: `{columns: [{column, type, nullable, default, is_primary_key}]}`
+    (renamed keys, `nullable` a boolean).
+- Minimum `pg` `^8.23.0`: `query` pipelines the read and `ROLLBACK` into 2 round-trips (was 3).
+- Upgraded `@modelcontextprotocol/sdk` to `^1.29.0`; requires Node >= 20.
+- Failures are returned as `isError: true` tool results instead of thrown protocol errors.
+
+### Removed
+
+- The `dotenv` dependency (a `.env` file no longer affects configuration).
+- Legacy `?` placeholder conversion; use native `$1`, `$2`.
+
+### Fixed
+
+- Reconnects lazily instead of crashing when the connection drops.
+- `connect_db` rejects an out-of-range `port`; an unreachable target no longer hangs queued calls.
+- Multi-statement input (`SELECT 1; DROP TABLE x`) is rejected.
+
+### Security
+
+- The connecting role is the real boundary; engine enforcement (rolled-back `BEGIN READ ONLY`) is
+  defense-in-depth. No client-side SQL parser; read-only is scoped per transaction, so it holds across
+  a transaction pooler like PgBouncer. Full threat model in [SECURITY.md](SECURITY.md).
+- Vulnerability disclosure via GitHub private security advisories.
+
+## [0.1.3] and earlier
+
+Releases prior to 0.2.0 predate this changelog.
+
+[0.2.0]: https://github.com/antonorlov/mcp-postgres-server/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # MCP PostgreSQL Server
 
-A Model Context Protocol server that provides PostgreSQL database operations. This server enables AI models to interact with PostgreSQL databases through a standardized interface.
+A Model Context Protocol (MCP) server for PostgreSQL: **read-only by default**,
+for local, Docker, RDS, Neon, and Supabase databases.
+
+The whole server is one file ([`src/index.ts`](src/index.ts), under 900 lines)
+with four runtime dependencies: the MCP SDK, `pg`, `pg-connection-string`, and
+`zod` (plus `ssh2`, an optional dependency used only for SSH tunneling).
+Read-only is enforced by PostgreSQL itself.
+
+Requires Node.js 20 or newer.
 
 ## Installation
 
@@ -18,7 +26,29 @@ npx mcp-postgres-server
 
 ## Configuration
 
-The server requires the following environment variables:
+The preferred way to configure the server is a single `DATABASE_URL`:
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "mcp-postgres-server"],
+      "env": {
+        "DATABASE_URL": "postgres://user:password@localhost:5432/mydb",
+        "PG_ALLOW_WRITE": "false"
+      }
+    }
+  }
+}
+```
+
+With `PG_ALLOW_WRITE` set to `"false"` the server has **read-only access** to the
+database. This is the default; set it to `"true"` only if the model must write.
+
+Alternatively, set the individual `PG_*` variables; they are used when
+`DATABASE_URL` is not set:
 
 ```json
 {
@@ -32,36 +62,132 @@ The server requires the following environment variables:
         "PG_PORT": "5432",
         "PG_USER": "your_user",
         "PG_PASSWORD": "your_password",
-        "PG_DATABASE": "your_database"
+        "PG_DATABASE": "your_database",
+        "PG_ALLOW_WRITE": "false"
       }
     }
   }
 }
 ```
 
-## Available Tools
+### Environment variables
 
-### 1. connect_db
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | - | Full connection string (preferred). Supports `?sslmode=` in the URL. |
+| `PG_HOST` | - | Database host (fallback when `DATABASE_URL` is not set) |
+| `PG_PORT` | `5432` | Database port |
+| `PG_USER` | - | Database user |
+| `PG_PASSWORD` | - | Database password |
+| `PG_DATABASE` | - | Database name |
+| `PG_ALLOW_WRITE` | `false` | When `true`, `execute` performs writes and reads are sent directly. Off (default) is read-only: `execute` refuses writes and each read runs in a `READ ONLY` transaction |
+| `PG_SSLMODE` | - | `disable` \| `allow` \| `prefer` \| `require` \| `verify-ca` \| `verify-full`. `require`/`allow`/`prefer` encrypt without verifying the certificate; `verify-ca`/`verify-full` verify (supply a CA via `PG_SSL_CA`). Unrecognized values fail at startup. **Limitation:** unlike libpq, `allow`/`prefer` do not fall back to plaintext (node-postgres has no opportunistic SSL), so a server without TLS needs `disable`. |
+| `PG_SSL_CA` | - | Path to a CA certificate file. Setting it by itself implies `verify-full` |
+| `PG_ENABLE_RUNTIME_CONNECT` | `false` | Register the `connect_db` tool (runtime credential switching) |
+| `PG_MAX_RESULT_BYTES` | `32768` | Byte budget for a `query` result sent to the model. Whole rows are kept while they fit; over the budget `returnedRows < rowCount` and `truncated: true` (if not even the first row fits, `returnedRows` is 0 with a hint). ~32 KiB ≈ 8k tokens; lower it for strict clients, raise it if your client allows more. |
+| `PG_STATEMENT_TIMEOUT` | `30000` | Statement timeout in milliseconds, applied to every session |
+| `PG_CONNECT_TIMEOUT` | `10000` | Timeout in milliseconds for a single connect attempt (raise it for slow links or SSH tunnels) |
+| `PG_SSH_HOST` | - | SSH bastion host. **Setting it enables tunneling**: the server reaches the database only through an SSH tunnel to this host (see below). Optional feature; needs the `ssh2` optional dependency. |
+| `PG_SSH_PORT` | `22` | SSH bastion port |
+| `PG_SSH_USER` | - | SSH username |
+| `PG_SSH_PRIVATE_KEY` | - | Path to a private key file. If unset, auth falls back like `ssh`: a running agent (`SSH_AUTH_SOCK`), then a default key (`~/.ssh/id_ed25519`, `id_rsa`, `id_ecdsa`) |
+| `PG_SSH_PASSPHRASE` | - | Passphrase for the private key, if encrypted |
+| `PG_SSH_AGENT` | - | `true` to use the ambient agent (`SSH_AUTH_SOCK`), or an explicit socket path / Windows named pipe (`\\.\pipe\openssh-ssh-agent`) |
+| `PG_SSH_PASSWORD` | - | SSH login password. Opt-in; a key or agent takes precedence. Prefer keys - a bastion often disables password auth. |
+| `PG_SSH_FINGERPRINT` | - | Pinned host-key fingerprint (`SHA256:...`). **Host-key verification is mandatory and set only this way**: without it the tunnel refuses to connect (fail-closed) |
+| `PG_SSH_KEEPALIVE_INTERVAL` | `15000` | SSH keepalive interval in ms; the tunnel drops after 3 unanswered keepalives, and the next call reconnects |
 
-Establish connection to PostgreSQL database using provided credentials.
+### Connecting over an SSH tunnel
 
-```javascript
-use_mcp_tool({
-  server_name: "postgres",
-  tool_name: "connect_db",
-  arguments: {
-    host: "localhost",
-    port: 5432,
-    user: "your_user",
-    password: "your_password",
-    database: "your_database"
+Set `PG_SSH_HOST` (plus auth and host-key verification) to reach a database that is only accessible
+through a bastion. The connection string / `PG_*` fields then describe the database **as seen from the
+bastion**:
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "mcp-postgres-server"],
+      "env": {
+        "DATABASE_URL": "postgres://mcp_readonly:secret@db.internal:5432/mydb?sslmode=verify-full",
+        "PG_SSH_HOST": "bastion.example.com",
+        "PG_SSH_USER": "jump",
+        "PG_SSH_PRIVATE_KEY": "/home/me/.ssh/id_ed25519",
+        "PG_SSH_FINGERPRINT": "SHA256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      }
+    }
   }
-});
+}
 ```
 
-### 2. query
+- **SSH changes only the transport.** Read-only enforcement, the result size cap, timeouts, and
+  `connect_db` behave exactly as on a direct connection, and no extra SQL is sent per query.
+- **Host-key verification is mandatory** via a pinned `PG_SSH_FINGERPRINT` - the tunnel will not
+  connect without it, so a man-in-the-middle bastion is refused. (Get the fingerprint with
+  `ssh-keyscan host | ssh-keygen -lf -`.)
+- **TLS validates the real database hostname.** With `verify-full`, the certificate is checked against
+  the database's own hostname (e.g. `db.internal`), not the loopback the tunnel binds locally, and
+  `rejectUnauthorized` is pinned on so an inherited `NODE_TLS_REJECT_UNAUTHORIZED=0` cannot disable it.
+- **`ssh2` is an optional dependency**, loaded only when `PG_SSH_HOST` is set, so a direct connection
+  never initializes it. npm installs optional dependencies by default; run
+  `npm install --omit=optional` to skip it entirely (a direct connection does not need it).
 
-Execute SELECT queries with optional prepared statement parameters. Supports both PostgreSQL-style ($1, $2) and MySQL-style (?) parameter placeholders.
+### Example configurations
+
+**Local Postgres:**
+
+```
+DATABASE_URL=postgres://mcp_readonly:secret@localhost:5432/mydb
+```
+
+**Postgres in Docker:** if the database runs in a container with a published
+port, connect to `localhost:<published-port>` as usual. If the *MCP server
+itself* runs inside a container and the database runs on your host machine,
+use `host.docker.internal` instead of `localhost`:
+
+```
+DATABASE_URL=postgres://mcp_readonly:secret@host.docker.internal:5432/mydb
+```
+
+**Amazon RDS:**
+
+```
+DATABASE_URL=postgres://mcp_readonly:secret@mydb.xxxxxx.us-east-1.rds.amazonaws.com:5432/mydb?sslmode=require
+```
+
+**Neon:**
+
+```
+DATABASE_URL=postgres://mcp_readonly:secret@ep-xxx-xxx.us-east-2.aws.neon.tech/mydb?sslmode=require
+```
+
+**Supabase:**
+
+```
+DATABASE_URL=postgres://postgres.xxxxxxxx:secret@aws-0-us-east-1.pooler.supabase.com:5432/postgres?sslmode=require
+```
+
+## Available Tools
+
+Tool availability depends on configuration:
+
+| Tool | Available |
+|------|-----------|
+| `query`, `list_schemas`, `list_tables`, `describe_table` | Always |
+| `execute` | Always (refuses writes unless `PG_ALLOW_WRITE=true`) |
+| `connect_db` | Only when `PG_ENABLE_RUNTIME_CONNECT=true` |
+
+### 1. query
+
+Execute a read-only SQL statement. Accepts `SELECT`, `WITH ... SELECT`,
+`EXPLAIN`, and `SHOW`. One statement per call - multi-statement input is rejected
+by the extended query protocol. In read-only mode (the default) the statement runs
+as `BEGIN READ ONLY`, the query, and `ROLLBACK` - three commands, roughly two
+network round trips with pipelining - so the database itself refuses any write.
+Supports PostgreSQL-style `$1, $2` prepared-statement parameters; values are bound
+by the driver and never spliced into the SQL text.
 
 ```javascript
 use_mcp_tool({
@@ -74,22 +200,12 @@ use_mcp_tool({
 });
 ```
 
-### 3. execute
+Returns compact JSON: `{"rows": [...], "rowCount": n, "returnedRows": n, "truncated": false}`.
+When the serialized rows exceed `PG_MAX_RESULT_BYTES`, only the rows that fit are returned
+(`returnedRows < rowCount`), `truncated` is `true`, and a hint suggests adding `LIMIT`/`WHERE`
+or selecting fewer columns.
 
-Execute INSERT, UPDATE, or DELETE queries with optional prepared statement parameters. Supports both PostgreSQL-style ($1, $2) and MySQL-style (?) parameter placeholders.
-
-```javascript
-use_mcp_tool({
-  server_name: "postgres",
-  tool_name: "execute",
-  arguments: {
-    sql: "INSERT INTO users (name, email) VALUES ($1, $2)",
-    params: ["John Doe", "john@example.com"]
-  }
-});
-```
-
-### 4. list_schemas
+### 2. list_schemas
 
 List all schemas in the connected database.
 
@@ -101,9 +217,10 @@ use_mcp_tool({
 });
 ```
 
-### 5. list_tables
+### 3. list_tables
 
-List tables in the connected database. Accepts an optional schema parameter (defaults to 'public').
+List tables in the connected database. Accepts an optional schema parameter
+(defaults to 'public').
 
 ```javascript
 // List tables in the 'public' schema (default)
@@ -123,57 +240,146 @@ use_mcp_tool({
 });
 ```
 
-### 6. describe_table
+### 4. describe_table
 
-Get the structure of a specific table. Accepts an optional schema parameter (defaults to 'public').
+Get the structure of a specific table (columns, types, nullability, defaults,
+primary keys). Accepts an optional schema parameter (defaults to 'public').
 
 ```javascript
-// Describe a table in the 'public' schema (default)
-use_mcp_tool({
-  server_name: "postgres",
-  tool_name: "describe_table",
-  arguments: {
-    table: "users"
-  }
-});
-
-// Describe a table in a specific schema
 use_mcp_tool({
   server_name: "postgres",
   tool_name: "describe_table",
   arguments: {
     table: "users",
-    schema: "my_schema"
+    schema: "my_schema"  // optional
+  }
+});
+```
+
+### 5. execute - requires `PG_ALLOW_WRITE=true`
+
+Execute an `INSERT`, `UPDATE`, `DELETE`, or DDL statement. Always registered, but
+in read-only mode (the default) it refuses with an error naming `PG_ALLOW_WRITE`
+and changes nothing - the statement never reaches the database. With
+`PG_ALLOW_WRITE=true` it runs: same `$1, $2` parameter handling as `query`, one
+complete statement per call, and the connecting role governs what it may do.
+Returns `{"rowCount": n, "command": "INSERT"}`.
+
+```javascript
+use_mcp_tool({
+  server_name: "postgres",
+  tool_name: "execute",
+  arguments: {
+    sql: "INSERT INTO users (name, email) VALUES ($1, $2)",
+    params: ["John Doe", "john@example.com"]
+  }
+});
+```
+
+### 6. connect_db - requires `PG_ENABLE_RUNTIME_CONNECT=true`
+
+Connect to a different PostgreSQL database at runtime using provided
+credentials. Not registered by default - prefer configuring credentials
+through the environment so they never pass through model-visible arguments.
+Session limits (`statement_timeout`, `idle_in_transaction_session_timeout`) are
+re-applied after every reconnect; read-only reads enforce read-only in their own
+`BEGIN READ ONLY` transaction.
+
+```javascript
+use_mcp_tool({
+  server_name: "postgres",
+  tool_name: "connect_db",
+  arguments: {
+    host: "localhost",
+    port: 5432,
+    user: "your_user",
+    password: "your_password",
+    database: "your_database"
   }
 });
 ```
 
 ## Features
 
-* Secure connection handling with automatic cleanup
-* Prepared statement support for query parameters
-* Support for both PostgreSQL-style ($1, $2) and MySQL-style (?) parameter placeholders
-* Comprehensive error handling and validation
-* TypeScript support
-* Automatic connection management
-* Supports PostgreSQL-specific syntax and features
+* Read-only by default; writes are an explicit opt-in (`PG_ALLOW_WRITE=true`)
+* Read-only enforced by the engine (`BEGIN READ ONLY`), never by client-side SQL parsing
+* Data access behind a small typed interface; the `pg` driver never leaks past it
+* `DATABASE_URL` support with SSL (`sslmode=disable|allow|prefer|require|verify-ca|verify-full`, custom CA)
+* Prepared-statement parameters: `$1`-style placeholders, bound by the driver
+* Result size cap (byte budget) with an explicit `truncated` flag instead of flooding the model's context
+* Session statement timeout plus a client deadline; transaction poolers may not preserve session settings
+* Errors returned as readable tool results with SQLSTATE-based hints, so the model can self-correct
+* Survives dropped connections - reconnects lazily instead of crashing
+* Optional SSH tunneling (`PG_SSH_*`) with mandatory host-key verification, loaded only when configured
+* MCP tool annotations (read-only / destructive hints) per spec 2025-11-25
 * Multi-schema support for database operations
 
 ## Security
 
-* Uses prepared statements to prevent SQL injection
-* Supports secure password handling through environment variables
-* Validates queries before execution
-* Automatically closes connections when done
+Full details, including the threat model and disclosure process, are in
+[SECURITY.md](SECURITY.md). The short version:
+
+1. **A least-privilege database role is the real boundary.** The MCP works with
+   existing credentials; creating or changing roles is not required. A dedicated
+   role is what actually guarantees writes are impossible.
+   On PostgreSQL 14+, the following is a starting point:
+
+   ```sql
+   CREATE ROLE mcp_readonly LOGIN PASSWORD 'change-me';
+   GRANT CONNECT ON DATABASE your_database TO mcp_readonly;
+   GRANT pg_read_all_data TO mcp_readonly;                          -- adds read privileges
+   ALTER ROLE mcp_readonly SET default_transaction_read_only = on;  -- read-only by default
+   ```
+
+   (On PostgreSQL 13 or older, grant `SELECT` explicitly instead of
+   `pg_read_all_data` - see [SECURITY.md](SECURITY.md).) The server warns on
+   stderr if you connect as a superuser. Read grants do not revoke existing
+   privileges, and defaults remain mutable; available functions, ownership and
+   inherited privileges also matter.
+
+2. **The engine enforces read-only.** There is no client-side SQL parsing. In
+   read-only mode every read runs in a rolled-back `BEGIN READ ONLY` transaction,
+   so PostgreSQL itself - which alone knows what a function, view, or rule does -
+   refuses any write with SQLSTATE 25006 and reverts any session change the
+   statement made. The extended protocol rejects multi-command strings.
+
+**Honest framing:** the read-only transaction is defense-in-depth on top of the
+role, not a replacement for it. Read-only mode stops a confused or prompt-injected
+model from *writing* to your database; it does not stop prompt injection carried in
+the row data a query returns. Don't point this server at production - use a replica,
+a snapshot, or a tightly scoped role. See [SECURITY.md](SECURITY.md).
 
 ## Error Handling
 
-The server provides detailed error messages for common issues:
+SQL and connection failures are returned as tool results (`isError: true`)
+with a message, the SQLSTATE code, and a hint where one is known - for
+example:
 
-* Connection failures
-* Invalid queries
-* Missing parameters
-* Database errors
+* `28P01` -> check `PG_USER`/`PG_PASSWORD`
+* `3D000` -> database does not exist, check `PG_DATABASE`
+* `42P01` -> relation not found, call `list_tables`
+* `42703` -> column not found, call `describe_table`
+* `57014` -> statement timeout, add `LIMIT` or simplify the query
+* `25006` -> server is read-only, set `PG_ALLOW_WRITE=true` to enable writes
+* `ECONNREFUSED`/`ENOTFOUND` -> check `PG_HOST`/`PG_PORT`/`DATABASE_URL`
+
+## Migrating from 0.1.x
+
+Not needed for new installs. Two behavior changes since 0.1.x:
+
+1. **Read-only by default.** The `execute` tool is always visible but refuses
+   writes (with an error naming the flag) unless `PG_ALLOW_WRITE=true`, and every
+   read runs inside an engine-enforced `READ ONLY` transaction. If your workflow
+   writes to the database, set `"PG_ALLOW_WRITE": "true"` to restore 0.1.x behavior.
+2. **`connect_db` is disabled by default.** Runtime connection switching (passing
+   credentials through tool arguments) requires `PG_ENABLE_RUNTIME_CONNECT=true`;
+   otherwise connection details come only from the environment.
+
+Tool names, parameter names, and `PG_*` variables are unchanged. Result payloads
+are now structured compact JSON for **every** tool (e.g. `query` returns
+`{rows, rowCount, returnedRows, truncated}` instead of a bare row array) - see
+[CHANGELOG.md](CHANGELOG.md) for the exact shapes before updating anything that
+parses tool output.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report privately via
+[GitHub security advisories](https://github.com/antonorlov/mcp-postgres-server/security/advisories/new)
+("Security" tab -> "Report a vulnerability"). Do **not** open a public issue.
+
+## The real boundary is the database role
+
+Read-only mode is **defense-in-depth, not a security boundary.** Client-side SQL
+filtering can never be a guarantee; the only real boundary is the privileges of
+the role you connect with. Prefer a least-privilege role:
+
+```sql
+CREATE ROLE mcp_readonly LOGIN PASSWORD 'change-me';
+GRANT CONNECT ON DATABASE your_database TO mcp_readonly;
+GRANT pg_read_all_data TO mcp_readonly;                          -- PG 14+
+ALTER ROLE mcp_readonly SET default_transaction_read_only = on;
+```
+
+On PG 13 or older, grant `SELECT ON ALL TABLES` in the schema and set matching
+`ALTER DEFAULT PRIVILEGES` instead of `pg_read_all_data`.
+
+A dedicated role is not required (existing credentials work), but avoid
+`superuser` / `rds_superuser` / `pg_execute_server_program` - they write
+regardless of grants; the server warns on stderr if you connect as a superuser.
+Read grants don't revoke other privileges; ownership, `PUBLIC` grants, and
+`SECURITY DEFINER` functions also matter.
+
+## How read-only is enforced
+
+No client-side SQL parsing - PostgreSQL is the enforcer. In read-only mode
+(default) every `query` runs as `BEGIN READ ONLY` + the bound statement (extended
+protocol, one command only) + `ROLLBACK`. The engine refuses any write with
+SQLSTATE 25006 - including a write hidden in a view, rule, or function - and
+reverts any session change; this holds even for a write-capable role. With
+`PG_ALLOW_WRITE=true` statements are sent directly and the role alone governs
+writes. `statement_timeout` and `idle_in_transaction_session_timeout` are set on
+connect (a pooler may not preserve them; the driver's `query_timeout` is the
+backstop).
+
+## Threat model
+
+**Stops:** a confused or prompt-injected model *writing* to your database
+(`DROP`/`DELETE`/`UPDATE`/`INSERT`, and exfiltration-by-write).
+
+**Does NOT stop: prompt injection via returned rows.** Anything a `SELECT`
+returns becomes model context; adversarial text in a row is not filtered, and
+with another tool that can reach the network it can still be exfiltrated. Limit
+what the role can `SELECT`, and be deliberate about which tools run alongside
+this one.
+
+**Do not point this server at production.** Use a replica, a snapshot, a dev
+copy, or a role scoped to the exact tables the task needs.
+
+## Scope
+
+- `connect_db` (runtime credential switching) is disabled unless
+  `PG_ENABLE_RUNTIME_CONNECT=true`; otherwise credentials come only from the
+  environment, never from the model.
+- Local stdio server only - no HTTP transport, tokens, or OAuth, so
+  remote-MCP attacks do not apply.
+
+## SSH tunneling (optional, `PG_SSH_HOST`)
+
+- **Host-key verification is mandatory and fail-closed:** a pinned
+  `PG_SSH_FINGERPRINT` must match, or the tunnel refuses to connect (a
+  man-in-the-middle bastion is rejected).
+- **Database TLS is verified end-to-end:** with `verify-full` the certificate is
+  checked against the real hostname, not the loopback the tunnel binds, and
+  `rejectUnauthorized` is pinned on against an inherited
+  `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+- Credentials (SSH key/password, DB password) come from the environment; `ssh2`
+  loads only when `PG_SSH_HOST` is set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "mcp-postgres-server",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-postgres-server",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "0.6.0",
-        "dotenv": "^16.4.7",
-        "pg": "^8.11.3"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "pg": "^8.23.0",
+        "pg-connection-string": "^2.14.0",
+        "zod": "^3.25.0"
       },
       "bin": {
         "mcp-postgres": "build/index.js"
@@ -19,19 +20,1077 @@
       "devDependencies": {
         "@types/node": "^20.11.24",
         "@types/pg": "^8.10.7",
-        "typescript": "^5.3.3"
+        "@types/ssh2": "^1.15.6",
+        "@vitest/coverage-v8": "^3.2.4",
+        "typescript": "^5.3.3",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "ssh2": "^1.17.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.6.0.tgz",
-      "integrity": "sha512-9rsDudGhDtMbvxohPoMMyAUOmEzQsOK+XFchh6gZGqo8sx9sBuZQs+CUttXqa8RZXKDaJRCN2tUtgGof7jRkkw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.17.25",
@@ -55,6 +1114,364 @@
         "pg-types": "^4.0.1"
       }
     },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.6.tgz",
+      "integrity": "sha512-oGdxhBqcRTwSTKFm+9EiKzkNVYRLEFkcW44lhguvBalGJbWfGnDt/ezwSUZc+SF9m9bMc3VyklNAtp7zICjS5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -62,6 +1479,105 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -73,6 +1589,96 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -82,44 +1688,553 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
       },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -128,6 +2243,339 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -135,23 +2583,113 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pg": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.14.1.tgz",
-      "integrity": "sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==",
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.7.0",
-        "pg-pool": "^3.8.0",
-        "pg-protocol": "^1.8.0",
-        "pg-types": "^2.1.0",
-        "pgpass": "1.x"
+        "ee-first": "1.1.1"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.1.1"
+        "pg-cloudflare": "^1.4.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -163,16 +2701,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
-      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
-      "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -195,18 +2733,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.8.0.tgz",
-      "integrity": "sha512-VBw3jiVm6ZOdLBTIcXLNdSotb6Iy3uOCwDGFAksZCXmi10nyRvnP2v3jl4d+IsLYRyXf6o9hIm/ZtUzlByNUdw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.8.0.tgz",
-      "integrity": "sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -292,6 +2830,64 @@
         "split2": "^4.1.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
@@ -342,19 +2938,131 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/safer-buffer": {
@@ -363,11 +3071,192 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -378,13 +3267,258 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.6.tgz",
+      "integrity": "sha512-u8KszXvGfU68hVcZpRHKG28T0krMuv2G5nDhiHaMLen/gIuFEgIJhaJuO69qjnXg5paSrbPMFfx3brNuN8eVSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -394,6 +3528,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense",
+      "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -426,6 +3598,424 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -436,12 +4026,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "mcp-postgres": "build/index.js"
       },
       "devDependencies": {
-        "@types/node": "^20.11.24",
+        "@types/node": "^20.19.0",
         "@types/pg": "^8.10.7",
         "@types/ssh2": "^1.15.6",
         "@vitest/coverage-v8": "^3.2.4",
@@ -1093,13 +1093,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.25.tgz",
-      "integrity": "sha512-bT+r2haIlplJUYtlZrEanFHdPIZTeiMeh/fSOEbOOfWf9uTn+lg8g0KU6Q3iMgjd9FLuuMAgfCNSkjUbxL6E3Q==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/pg": {
@@ -3583,9 +3583,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "zod": "^3.25.0"
   },
   "devDependencies": {
-    "@types/node": "^20.11.24",
+    "@types/node": "^20.19.0",
     "@types/pg": "^8.10.7",
     "@types/ssh2": "^1.15.6",
     "@vitest/coverage-v8": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,24 @@
 {
   "name": "mcp-postgres-server",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A Model Context Protocol server for PostgreSQL database operations",
   "type": "module",
+  "mcpName": "io.github.antonorlov/mcp-postgres-server",
   "bin": {
     "mcp-postgres": "./build/index.js"
   },
   "files": [
     "build"
   ],
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "prepare": "npm run build",
     "watch": "tsc --watch",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js"
   },
   "keywords": [
@@ -27,14 +33,18 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "0.6.0",
-    "dotenv": "^16.4.7",
-    "pg": "^8.11.3"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "pg": "^8.23.0",
+    "pg-connection-string": "^2.14.0",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",
     "@types/pg": "^8.10.7",
-    "typescript": "^5.3.3"
+    "@types/ssh2": "^1.15.6",
+    "@vitest/coverage-v8": "^3.2.4",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.4"
   },
   "repository": {
     "type": "git",
@@ -42,5 +52,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "optionalDependencies": {
+    "ssh2": "^1.17.0"
   }
 }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -3,47 +3,145 @@
 startCommand:
   type: stdio
   configSchema:
-    # JSON Schema defining the configuration options for the MCP.
+    # Configuration for mcp-postgres-server 0.2.0. Connect with either a single
+    # DATABASE_URL (preferred) or the individual PG_* fields. Read-only by default.
     type: object
-    required:
-      - pgHost
-      - pgUser
-      - pgPassword
-      - pgDatabase
     properties:
+      databaseUrl:
+        type: string
+        description: >-
+          Full connection string, e.g.
+          postgres://user:pass@host:5432/db?sslmode=require (preferred). If set,
+          the individual host/port/user/password/database fields are ignored.
       pgHost:
         type: string
-        description: Hostname for the PostgreSQL server
+        description: Database host (used when databaseUrl is not set)
       pgPort:
         type: number
-        description: Port for the PostgreSQL server
+        description: Database port (used when databaseUrl is not set)
         default: 5432
       pgUser:
         type: string
-        description: PostgreSQL user name
+        description: Database user (used when databaseUrl is not set)
       pgPassword:
         type: string
-        description: PostgreSQL user's password
+        description: Database password (used when databaseUrl is not set)
       pgDatabase:
         type: string
-        description: PostgreSQL database name
+        description: Database name (used when databaseUrl is not set)
+      pgSslmode:
+        type: string
+        enum: [disable, allow, prefer, require, verify-ca, verify-full]
+        description: >-
+          TLS mode. require/allow/prefer encrypt without verifying the certificate;
+          verify-ca/verify-full verify it (supply a CA via pgSslCa). Unlike libpq,
+          allow/prefer do NOT fall back to plaintext - use disable for a server
+          without TLS. Applies to the PG_* fields; for databaseUrl put sslmode in
+          the URL instead.
+      pgSslCa:
+        type: string
+        description: Path to a CA certificate file. Setting it alone implies verify-full.
+      pgAllowWrite:
+        type: boolean
+        default: false
+        description: >-
+          Enable writes. Off by default: the execute tool is present but refuses
+          writes and each read runs in a READ ONLY transaction. When true, execute
+          performs writes and reads are sent directly.
+      pgEnableRuntimeConnect:
+        type: boolean
+        description: >-
+          Register the connect_db tool, which switches database at runtime via
+          tool arguments. Off by default.
+        default: false
+      pgMaxResultBytes:
+        type: number
+        description: >-
+          Byte budget for a query result sent to the model. Whole rows are kept up
+          to the budget; over it, returnedRows < rowCount and truncated is true.
+        default: 32768
+      pgStatementTimeout:
+        type: number
+        description: Per-statement timeout in milliseconds, applied to every session.
+        default: 30000
+      pgConnectTimeout:
+        type: number
+        description: Timeout in milliseconds for a single connect attempt.
+        default: 10000
+      pgSshHost:
+        type: string
+        description: >-
+          SSH bastion host. Setting it enables tunneling: the server reaches the
+          database only through an SSH tunnel to this host, which forwards to the
+          database from its own network. The database URL/host is interpreted from
+          the bastion's network. Optional; needs the ssh2 optional dependency.
+      pgSshPort:
+        type: number
+        description: SSH bastion port.
+        default: 22
+      pgSshUser:
+        type: string
+        description: SSH username.
+      pgSshPrivateKey:
+        type: string
+        description: >-
+          Path to a private key file. If unset, auth falls back like ssh: a
+          running agent (SSH_AUTH_SOCK), then a default key (~/.ssh/id_ed25519,
+          id_rsa, id_ecdsa).
+      pgSshPassphrase:
+        type: string
+        description: Passphrase for the private key, if encrypted.
+      pgSshAgent:
+        type: string
+        description: >-
+          'true' to use the ambient agent (SSH_AUTH_SOCK), or an explicit socket
+          path / Windows named pipe.
+      pgSshPassword:
+        type: string
+        description: >-
+          SSH login password (opt-in). A key or agent takes precedence; prefer
+          keys, as bastions often disable password auth.
+      pgSshFingerprint:
+        type: string
+        description: >-
+          Pinned host-key fingerprint (SHA256:...). Host-key verification is
+          mandatory and set only this way: without it the tunnel refuses to connect.
+      pgSshKeepaliveInterval:
+        type: number
+        description: SSH keepalive interval in ms; the tunnel drops after 3 unanswered keepalives.
+        default: 15000
   commandFunction:
-    # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
+    # Builds the CLI command and environment from the config. Only the fields
+    # that are set are passed through, so unset options fall back to defaults.
     |-
-    (config) => ({
-      command: 'node',
-      args: ['build/index.js'],
-      env: {
-        PG_HOST: config.pgHost,
-        PG_PORT: config.pgPort || 5432,
-        PG_USER: config.pgUser,
-        PG_PASSWORD: config.pgPassword,
-        PG_DATABASE: config.pgDatabase
+    (config) => {
+      const env = {};
+      if (config.databaseUrl) {
+        env.DATABASE_URL = config.databaseUrl;
+      } else {
+        if (config.pgHost) env.PG_HOST = config.pgHost;
+        if (config.pgPort) env.PG_PORT = String(config.pgPort);
+        if (config.pgUser) env.PG_USER = config.pgUser;
+        if (config.pgPassword) env.PG_PASSWORD = config.pgPassword;
+        if (config.pgDatabase) env.PG_DATABASE = config.pgDatabase;
       }
-    })
+      if (config.pgSslmode) env.PG_SSLMODE = config.pgSslmode;
+      if (config.pgSslCa) env.PG_SSL_CA = config.pgSslCa;
+      if (config.pgAllowWrite) env.PG_ALLOW_WRITE = 'true';
+      if (config.pgEnableRuntimeConnect) env.PG_ENABLE_RUNTIME_CONNECT = 'true';
+      if (config.pgMaxResultBytes) env.PG_MAX_RESULT_BYTES = String(config.pgMaxResultBytes);
+      if (config.pgStatementTimeout) env.PG_STATEMENT_TIMEOUT = String(config.pgStatementTimeout);
+      if (config.pgConnectTimeout) env.PG_CONNECT_TIMEOUT = String(config.pgConnectTimeout);
+      if (config.pgSshHost) env.PG_SSH_HOST = config.pgSshHost;
+      if (config.pgSshPort) env.PG_SSH_PORT = String(config.pgSshPort);
+      if (config.pgSshUser) env.PG_SSH_USER = config.pgSshUser;
+      if (config.pgSshPrivateKey) env.PG_SSH_PRIVATE_KEY = config.pgSshPrivateKey;
+      if (config.pgSshPassphrase) env.PG_SSH_PASSPHRASE = config.pgSshPassphrase;
+      if (config.pgSshAgent) env.PG_SSH_AGENT = config.pgSshAgent;
+      if (config.pgSshPassword) env.PG_SSH_PASSWORD = config.pgSshPassword;
+      if (config.pgSshFingerprint) env.PG_SSH_FINGERPRINT = config.pgSshFingerprint;
+      if (config.pgSshKeepaliveInterval) env.PG_SSH_KEEPALIVE_INTERVAL = String(config.pgSshKeepaliveInterval);
+      return { command: 'node', args: ['build/index.js'], env };
+    }
   exampleConfig:
-    pgHost: localhost
-    pgPort: 5432
-    pgUser: example_user
-    pgPassword: example_password
-    pgDatabase: example_db
+    databaseUrl: postgres://mcp_readonly:secret@localhost:5432/mydb?sslmode=require

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,520 +1,889 @@
 #!/usr/bin/env node
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+/**
+ * mcp-postgres-server - MCP server for PostgreSQL, read-only by default.
+ * Sections: config / connection / database / tools / main.
+ * Read-only is engine-enforced (BEGIN READ ONLY); the only real boundary is the connecting role.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ErrorCode,
-  ListToolsRequestSchema,
-  McpError,
-} from '@modelcontextprotocol/sdk/types.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import pg from 'pg';
-const { Client } = pg;
-import { config } from 'dotenv';
+import { parse as parseConnectionString, toClientConfig } from 'pg-connection-string';
+import { z } from 'zod';
+import net from 'node:net';
+import { realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 
-// Load environment variables
-config();
+const VERSION: string = createRequire(import.meta.url)('../package.json').version;
 
-interface DatabaseConfig {
+const DEFAULT_PORT = 5432;
+const DEFAULT_SSH_PORT = 22;
+const DEFAULT_SCHEMA = 'public';
+
+// --- config - all environment handling ---
+
+// PG_SSH_*; consumed only by the optional ssh-connector. Host-key verification is mandatory: the
+// connector fails closed unless a pinned fingerprint is given.
+export interface SshConfig {
   host: string;
   port: number;
-  user: string;
-  password: string;
-  database: string;
+  user?: string;
+  privateKeyPath?: string;
+  passphrase?: string;
+  agent?: string;
+  password?: string;
+  fingerprint?: string;
+  keepaliveIntervalMs: number;
 }
 
-// Type guard for error objects
-function isErrorWithMessage(error: unknown): error is { message: string } {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'message' in error &&
-    typeof (error as Record<string, unknown>).message === 'string'
-  );
+export interface ServerConfig {
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  ssl?: boolean | { rejectUnauthorized?: boolean; ca?: string; checkServerIdentity?: (...args: unknown[]) => Error | undefined };
+  readOnly: boolean;
+  maxResultBytes: number;
+  statementTimeoutMs: number;
+  connectTimeoutMs: number;
+  allowRuntimeConnect: boolean;
+  // Present only when PG_SSH_HOST is set; selects the optional ssh-connector. undefined = direct.
+  ssh?: SshConfig;
 }
 
-// Helper to get error message
-function getErrorMessage(error: unknown): string {
-  if (isErrorWithMessage(error)) {
-    return error.message;
+function nonEmpty(raw: string | undefined): string | undefined {
+  return raw !== undefined && raw !== '' ? raw : undefined;
+}
+
+function positiveIntOr(raw: string | undefined, fallback: number): number {
+  const n = raw !== undefined ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function isValidPort(n: number): boolean {
+  return Number.isInteger(n) && n >= 1 && n <= 65535;
+}
+
+// Uniform message for a bad port; isValidPort is the single source for the rule itself.
+function portRangeError(subject: string): string {
+  return `${subject}: must be a TCP port between 1 and 65535`;
+}
+
+// Junk falls back to the default; out of range throws rather than hanging a connect.
+function parsePort(raw: string | undefined): number | undefined {
+  const value = nonEmpty(raw);
+  if (value === undefined) return undefined;
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n)) return DEFAULT_PORT;
+  if (!isValidPort(n)) {
+    throw new Error(portRangeError(`invalid PG_PORT '${value}'`));
   }
-  return String(error);
+  return n;
 }
 
-// Helper to convert ? parameters to $1, $2, etc.
-function convertToNamedParams(query: string): string {
-  let paramIndex = 0;
-  return query.replace(/\?/g, () => `$${++paramIndex}`);
+function parseSshPort(raw: string | undefined): number {
+  const value = nonEmpty(raw);
+  if (value === undefined) return DEFAULT_SSH_PORT;
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n)) return DEFAULT_SSH_PORT;
+  if (!isValidPort(n)) {
+    throw new Error(portRangeError(`invalid PG_SSH_PORT '${value}'`));
+  }
+  return n;
 }
 
-class PostgresServer {
-  private server: Server;
-  private client: pg.Client | null = null;
-  private config: DatabaseConfig | null = null;
+function parseSshConfig(env: Record<string, string | undefined>): SshConfig | undefined {
+  const host = nonEmpty(env.PG_SSH_HOST);
+  if (host === undefined) return undefined;
+  return {
+    host,
+    port: parseSshPort(env.PG_SSH_PORT),
+    user: nonEmpty(env.PG_SSH_USER),
+    privateKeyPath: nonEmpty(env.PG_SSH_PRIVATE_KEY),
+    passphrase: nonEmpty(env.PG_SSH_PASSPHRASE),
+    agent: nonEmpty(env.PG_SSH_AGENT),
+    password: nonEmpty(env.PG_SSH_PASSWORD),
+    fingerprint: nonEmpty(env.PG_SSH_FINGERPRINT),
+    keepaliveIntervalMs: positiveIntOr(env.PG_SSH_KEEPALIVE_INTERVAL, 15000),
+  };
+}
 
-  constructor() {
-    this.server = new Server(
-      {
-        name: 'postgres-server',
-        version: '1.0.0',
-      },
-      {
-        capabilities: {
-          tools: {},
-        },
-      }
-    );
+// pg lets these URL params override our `ssl` option (`?sslmode=verify-full&ssl=0` connects
+// plaintext), so we strip them. URL cert paths unsupported; use PG_SSL_CA.
+const SSL_URL_PARAMS = new Set(['ssl', 'sslmode', 'sslnegotiation', 'sslcert', 'sslkey', 'sslrootcert']);
 
-    this.setupToolHandlers();
-    
-    // Error handling
-    this.server.onerror = (error) => console.error('[MCP Error]', error);
-    const handleTermination = async () => {
+function splitConnectionUrl(connectionString: string): { base: string; params: URLSearchParams } {
+  const q = connectionString.indexOf('?');
+  return q === -1
+    ? { base: connectionString, params: new URLSearchParams() }
+    : { base: connectionString.slice(0, q), params: new URLSearchParams(connectionString.slice(q + 1)) };
+}
+
+function ciGet(params: URLSearchParams, name: string): string | undefined {
+  for (const [key, value] of params) {
+    if (key.toLowerCase() === name) return value;
+  }
+  return undefined;
+}
+
+// Matched by DECODED name, so a percent-encoded `%73sl=0` is caught too.
+function stripSslParams(connectionString: string): string {
+  const { base, params } = splitConnectionUrl(connectionString);
+  for (const key of [...params.keys()]) {
+    if (SSL_URL_PARAMS.has(key.toLowerCase())) params.delete(key);
+  }
+  const rest = params.toString();
+  return rest ? `${base}?${rest}` : base;
+}
+
+const KNOWN_SSLMODES = new Set(['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']);
+
+// ssl options for a sslmode via pg-connection-string (useLibpqCompat), so libpq semantics aren't
+// hand-rolled. A CA alone implies verify-full; unknown modes fail loudly.
+function sslForMode(sslMode: string | undefined, caPath: string | undefined): ServerConfig['ssl'] {
+  if (sslMode === undefined && caPath === undefined) return undefined;
+  const requested = sslMode ?? 'verify-full';
+  if (!KNOWN_SSLMODES.has(requested)) {
+    throw new Error(`unrecognized sslmode '${requested}': use ${[...KNOWN_SSLMODES].join(' | ')}`);
+  }
+  // pg-connection-string has no 'allow' case (libpq prefers non-SSL, impossible in node); alias to prefer.
+  const mode = requested === 'allow' ? 'prefer' : requested;
+  const params = new URLSearchParams({ sslmode: mode });
+  if (caPath !== undefined) params.set('sslrootcert', caPath);
+  const ssl = parseConnectionString(`postgres://h/d?${params.toString()}`, { useLibpqCompat: true }).ssl as ServerConfig['ssl'];
+  /**
+   * For verifying modes pg-connection-string leaves rejectUnauthorized unset, so it inherits Node's
+   * default, which NODE_TLS_REJECT_UNAUTHORIZED=0 flips to "no verification". Pin it so our policy
+   * survives an inherited global bypass. require/prefer keep their deliberate false.
+   */
+  if (typeof ssl === 'object' && ssl !== null && ssl.rejectUnauthorized === undefined && (mode === 'verify-ca' || mode === 'verify-full')) {
+    ssl.rejectUnauthorized = true;
+  }
+  return ssl;
+}
+
+export function loadConfig(env: Record<string, string | undefined>): ServerConfig {
+  const connectionString = nonEmpty(env.DATABASE_URL);
+
+  // TLS precedence (case-insensitive): URL sslmode, then URL ssl=true|false, then PG_SSLMODE.
+  let sslMode: string | undefined;
+  if (connectionString !== undefined) {
+    const params = splitConnectionUrl(connectionString).params;
+    sslMode = ciGet(params, 'sslmode')?.toLowerCase();
+    if (sslMode === undefined) {
+      // ssl=true means verify (native pg default), NOT the no-verify `require`.
+      const flag = ciGet(params, 'ssl')?.toLowerCase();
+      if (flag === 'true' || flag === '1') sslMode = 'verify-full';
+      else if (flag === 'false' || flag === '0') sslMode = 'disable';
+    }
+  }
+  if (sslMode === undefined) sslMode = nonEmpty(env.PG_SSLMODE)?.toLowerCase();
+  const caPath = nonEmpty(env.PG_SSL_CA);
+  const ssl = sslForMode(sslMode, caPath);
+
+  return {
+    connectionString: connectionString !== undefined ? stripSslParams(connectionString) : undefined,
+    host: env.PG_HOST,
+    port: parsePort(env.PG_PORT),
+    user: env.PG_USER,
+    password: env.PG_PASSWORD,
+    database: env.PG_DATABASE,
+    ssl,
+    readOnly: env.PG_ALLOW_WRITE !== 'true',
+    maxResultBytes: positiveIntOr(env.PG_MAX_RESULT_BYTES, 32768),
+    statementTimeoutMs: positiveIntOr(env.PG_STATEMENT_TIMEOUT, 30000),
+    connectTimeoutMs: positiveIntOr(env.PG_CONNECT_TIMEOUT, 10000),
+    allowRuntimeConnect: env.PG_ENABLE_RUNTIME_CONNECT === 'true',
+    ssh: parseSshConfig(env),
+  };
+}
+
+// --- connection - client construction (injectable for tests) ---
+
+/**
+ * query_timeout must exceed statement_timeout: it is the client-side deadline that outlives the
+ * server timeout on a stalled socket (in pipeline mode it destroys the connection when it fires).
+ * pipeline sends query and ROLLBACK in one round-trip (pg 8.23+).
+ */
+export function baseClientOptions(cfg: ServerConfig) {
+  return {
+    connectionTimeoutMillis: cfg.connectTimeoutMs,
+    query_timeout: cfg.statementTimeoutMs + cfg.connectTimeoutMs,
+    pipeline: true,
+    ...(cfg.ssl !== undefined ? { ssl: cfg.ssl } : {}),
+  };
+}
+
+// pg-connection-string keeps the brackets on an IPv6 literal (`[::1]`), which getaddrinfo can't
+// resolve; strip them. Non-IPv6 hosts pass through.
+function normalizeHost(host: string | undefined): string | undefined {
+  if (host === undefined) return host;
+  const m = /^\[(.+)\]$/.exec(host);
+  return m !== null && net.isIP(m[1]) !== 0 ? m[1] : host;
+}
+
+/**
+ * Resolve the COMPLETE pg client options once, for both connectors: full connection-string settings
+ * (application_name, options/search_path, credentials) via pg-connection-string, our ssl policy
+ * (URL ssl params were stripped in loadConfig), a normalized IPv6 host, and the shared options. A
+ * tunneling connector reuses this and overrides only the endpoint (host/port) and TLS servername.
+ */
+export function resolveClientOptions(cfg: ServerConfig): pg.ClientConfig {
+  const parsed: pg.ClientConfig = cfg.connectionString !== undefined
+    ? toClientConfig(parseConnectionString(cfg.connectionString))
+    : { host: cfg.host, port: cfg.port, user: cfg.user, password: cfg.password, database: cfg.database };
+  const options: pg.ClientConfig = { ...parsed, ...baseClientOptions(cfg) };
+  options.host = normalizeHost(options.host ?? undefined);
+  // Validate before connect (a URL `?port=` lands here too), else pg wraps an out-of-range value
+  // and ERR_SOCKET_BAD_PORT crashes the process.
+  if (options.port !== undefined && !isValidPort(options.port)) {
+    throw new Error(portRangeError(`invalid port ${options.port}`));
+  }
+  return options;
+}
+
+export function defaultClientFactory(cfg: ServerConfig): pg.Client {
+  return new pg.Client(resolveClientOptions(cfg));
+}
+
+// A live, connected pg client plus any resources behind it (e.g. an SSH tunnel). close() releases
+// all of them and is idempotent - the single lifecycle owner every cleanup path goes through.
+export interface Connection {
+  client: pg.Client;
+  close(): Promise<void>;
+}
+
+/**
+ * Opens a live Connection: the returned client is already connected (and any resource behind it is
+ * up); on failure it rejects having released what it opened. Injected so transports (SSH, pooling)
+ * and tests vary without the database or tool layers knowing.
+ */
+export interface Connector {
+  connect(cfg: ServerConfig): Promise<Connection>;
+}
+
+// A plain pg client with no extra resources. On connect failure it ends the half-open socket so the
+// original error survives; close() ends the socket.
+export const defaultConnector: Connector = {
+  async connect(cfg) {
+    const client = defaultClientFactory(cfg);
+    try {
+      await client.connect();
+    } catch (err) {
+      await client.end().catch(() => undefined);
+      throw err;
+    }
+    return { client, close: () => client.end().catch(() => undefined) };
+  },
+};
+
+// Force pg's EXTENDED protocol, so the engine rejects multi-command strings. (queryMode lags in
+// @types/pg, hence the cast.)
+function extendedQuery(text: string, values: unknown[]): pg.QueryConfig {
+  return { text, values, queryMode: 'extended' } as pg.QueryConfig & { queryMode: string };
+}
+
+// --- database - typed, application-owned data access (hides pg.Client) ---
+
+export interface QueryData {
+  rows: unknown[];
+  rowCount: number;
+  returnedRows: number;
+  truncated: boolean;
+  hint?: string;
+}
+export interface ExecData {
+  rowCount: number | null;
+  command: string;
+}
+export interface ColumnInfo {
+  column: string;
+  type: string;
+  nullable: boolean;
+  default: string | null;
+  is_primary_key: boolean;
+}
+
+export interface DatabaseError {
+  message: string;
+  code?: string;
+  hint?: string;
+}
+
+export type Result<T> = { ok: true; data: T } | { ok: false; error: DatabaseError };
+
+// Typed data access that owns the pg client (never leaks it), so tool handlers depend on this
+// contract rather than on pg.
+export interface Database {
+  query(sql: string, params?: unknown[]): Promise<Result<QueryData>>;
+  execute(sql: string, params?: unknown[]): Promise<Result<ExecData>>;
+  listSchemas(): Promise<Result<{ schemas: string[] }>>;
+  listTables(schema: string): Promise<Result<{ tables: string[] }>>;
+  describeTable(schema: string, table: string): Promise<Result<{ columns: ColumnInfo[] }>>;
+  retarget(target: { host: string; port?: number; user: string; password: string; database: string }): Promise<Result<{ host: string; database: string }>>;
+  close(): Promise<void>;
+}
+
+/**
+ * Keep whole rows whose compact-JSON size fits maxBytes, so what the model receives is bounded by
+ * payload size, not an arbitrary row count. The budget is strict: if not even the first row fits,
+ * none are returned (the caller reports that), so the response never blows past the budget.
+ */
+export function capBySize<T>(rows: T[], maxBytes: number): { rows: T[]; truncated: boolean } {
+  const kept: T[] = [];
+  let bytes = 2; // enclosing []
+  for (const row of rows) {
+    const size = Buffer.byteLength(JSON.stringify(row), 'utf8') + 1; // + separator
+    if (bytes + size > maxBytes) break;
+    kept.push(row);
+    bytes += size;
+  }
+  return { rows: kept, truncated: kept.length < rows.length };
+}
+
+// SQLSTATE / syscall codes mapped to actionable hints for the model.
+const PG_ERROR_HINTS: Record<string, string> = {
+  '28P01': 'authentication failed: check PG_USER and PG_PASSWORD',
+  '3D000': 'database does not exist: check PG_DATABASE',
+  ECONNREFUSED: 'could not reach the database server: check PG_HOST, PG_PORT, or DATABASE_URL',
+  ENOTFOUND: 'could not resolve the database host: check PG_HOST, PG_PORT, or DATABASE_URL',
+  '42P01': 'relation not found: call list_tables to see the available tables',
+  '42703': 'column not found: call describe_table to see the table structure',
+  '57014': 'statement timeout exceeded: add a LIMIT clause or simplify the query',
+  '25006': 'the server is read-only by default (since 0.2.0); set PG_ALLOW_WRITE=true to enable writes',
+};
+
+export function classifyPgError(err: unknown): DatabaseError {
+  let message = String(err);
+  let code: string | undefined;
+  if (typeof err === 'object' && err !== null) {
+    const e = err as Record<string, unknown>;
+    if (typeof e.message === 'string' && e.message !== '') message = e.message;
+    if (typeof e.code === 'string') code = e.code;
+  }
+  const hint = code !== undefined ? PG_ERROR_HINTS[code] : undefined;
+  return {
+    message,
+    ...(code !== undefined ? { code } : {}),
+    ...(hint !== undefined ? { hint } : {}),
+  };
+}
+
+// Owns one lazily-connected pg client; reconnects after errors and re-applies session settings on
+// every (re)connect.
+export function createDatabase(
+  config: ServerConfig,
+  connector: Connector = defaultConnector
+): Database {
+  let activeConfig: ServerConfig = { ...config };
+  let connection: Connection | null = null;
+  // Teardowns started off the op queue (the client 'error' handler) accumulate here so close() can
+  // await them, and cleanup failures are logged in one place, never thrown.
+  let pendingCleanup: Promise<void> = Promise.resolve();
+
+  // Release a connection once; a cleanup failure is logged, never thrown or left unhandled, so it
+  // can't mask an original error.
+  function teardown(conn: Connection): Promise<void> {
+    const done = Promise.resolve()
+      .then(() => conn.close())
+      .catch((err: unknown) => {
+        console.error(`[postgres-server] connection cleanup failed: ${classifyPgError(err).message}`);
+      });
+    pendingCleanup = pendingCleanup.then(() => done);
+    return done;
+  }
+
+  // One queue: ops run one at a time, so parallel calls cannot double-connect or tangle BEGIN/ROLLBACK.
+  let chain: Promise<unknown> = Promise.resolve();
+  function serialized<T>(fn: () => Promise<T>): Promise<T> {
+    const run = chain.then(fn);
+    chain = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  async function applySessionSettings(c: pg.Client): Promise<void> {
+    // Bound-value set_config (no interpolation). Both are best-effort under a transaction pooler -
+    // the client-side query_timeout is the real backstop.
+    const timeoutMs = String(Math.max(0, Math.floor(activeConfig.statementTimeoutMs)));
+    await c.query('SELECT set_config($1, $3, false), set_config($2, $3, false)', [
+      'statement_timeout',
+      'idle_in_transaction_session_timeout',
+      timeoutMs,
+    ]);
+    if (activeConfig.readOnly) {
       try {
-        await this.cleanup();
-      } catch (error) {
-        console.error('Error during cleanup:', error);
-        process.exit(1);
-      }
-      process.exit(0);
-    };
-    process.on('SIGINT', handleTermination);
-    process.stdin.on('close', handleTermination);
-  }
-
-  private async cleanup() {
-    if (this.client) {
-      await this.client.end();
-    }
-    await this.server.close();
-  }
-
-  private async ensureConnection() {
-    if (!this.config) {
-      // Try to use environment variables if no explicit config was provided
-      const envConfig = this.getEnvConfig();
-      
-      if (envConfig) {
-        this.config = envConfig;
-        console.error('[MCP Info] Using database config from environment variables');
-      } else {
-        throw new McpError(
-          ErrorCode.InvalidRequest,
-          'Database configuration not set. Use connect_db tool first or set environment variables.'
-        );
-      }
-    }
-
-    if (!this.client) {
-      try {
-        this.client = new Client(this.config);
-        await this.client.connect();
-      } catch (error) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          `Failed to connect to database: ${getErrorMessage(error)}`
-        );
-      }
-    }
-  }
-  
-  private getEnvConfig(): DatabaseConfig | null {
-    const { PG_HOST, PG_USER, PG_PASSWORD, PG_DATABASE, PG_PORT } = process.env;
-    
-    if (PG_HOST && PG_USER && PG_PASSWORD && PG_DATABASE) {
-      return {
-        host: PG_HOST,
-        port: PG_PORT ? parseInt(PG_PORT, 10) : 5432,
-        user: PG_USER,
-        password: PG_PASSWORD,
-        database: PG_DATABASE
-      };
-    }
-    
-    return null;
-  }
-
-  private setupToolHandlers() {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [
-        {
-          name: 'connect_db',
-          description: 'Connect to PostgreSQL database. NOTE: Default connection exists - only use when requested or if other commands fail',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              host: {
-                type: 'string',
-                description: 'Database host',
-              },
-              port: {
-                type: 'number',
-                description: 'Database port (default: 5432)',
-              },
-              user: {
-                type: 'string',
-                description: 'Database user',
-              },
-              password: {
-                type: 'string',
-                description: 'Database password',
-              },
-              database: {
-                type: 'string',
-                description: 'Database name',
-              },
-            },
-            required: ['host', 'user', 'password', 'database'],
-          },
-        },
-        {
-          name: 'query',
-          description: 'Execute a SELECT query',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              sql: {
-                type: 'string',
-                description: 'SQL SELECT query (use $1, $2, etc. for parameters)',
-              },
-              params: {
-                type: 'array',
-                items: {
-                  type: ['string', 'number', 'boolean', 'null'],
-                },
-                description: 'Query parameters (optional)',
-              },
-            },
-            required: ['sql'],
-          },
-        },
-        {
-          name: 'execute',
-          description: 'Execute an INSERT, UPDATE, or DELETE query',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              sql: {
-                type: 'string',
-                description: 'SQL query (INSERT, UPDATE, DELETE) (use $1, $2, etc. for parameters)',
-              },
-              params: {
-                type: 'array',
-                items: {
-                  type: ['string', 'number', 'boolean', 'null'],
-                },
-                description: 'Query parameters (optional)',
-              },
-            },
-            required: ['sql'],
-          },
-        },
-        {
-          name: 'list_schemas',
-          description: 'List all schemas in the database',
-          inputSchema: {
-            type: 'object',
-            properties: {},
-            required: [],
-          },
-        },
-        {
-          name: 'list_tables',
-          description: 'List tables in the database',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              schema: {
-                type: 'string',
-                description: 'Schema name (default: public)',
-              },
-            },
-            required: [],
-          },
-        },
-        {
-          name: 'describe_table',
-          description: 'Get table structure',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              table: {
-                type: 'string',
-                description: 'Table name',
-              },
-              schema: {
-                type: 'string',
-                description: 'Schema name (default: public)',
-              },
-            },
-            required: ['table'],
-          },
-        },
-      ],
-    }));
-  
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      switch (request.params.name) {
-        case 'connect_db':
-          return await this.handleConnectDb(request.params.arguments);
-        case 'query':
-          return await this.handleQuery(request.params.arguments);
-        case 'execute':
-          return await this.handleExecute(request.params.arguments);
-        case 'list_schemas':
-          return await this.handleListSchemas();
-        case 'list_tables':
-          return await this.handleListTables(request.params.arguments);
-        case 'describe_table':
-          return await this.handleDescribeTable(request.params.arguments);
-        default:
-          throw new McpError(
-            ErrorCode.MethodNotFound,
-            `Unknown tool: ${request.params.name}`
+        const check = await c.query("SELECT current_setting('is_superuser') AS is_superuser");
+        if (check.rows[0]?.is_superuser === 'on') {
+          console.error(
+            '[postgres-server] warning: connected as a superuser. Read-only is enforced by the engine (BEGIN READ ONLY); the only real boundary is a least-privilege role - see SECURITY.md.'
           );
+        }
+      } catch {
+        // advisory only - never fail the connection over it
       }
+    }
+  }
+
+  async function getClient(): Promise<pg.Client> {
+    if (connection !== null) return connection.client;
+    if (
+      activeConfig.connectionString === undefined &&
+      activeConfig.host === undefined &&
+      activeConfig.user === undefined &&
+      activeConfig.database === undefined
+    ) {
+      throw new Error(
+        'no database configured: set DATABASE_URL or PG_HOST/PG_USER/PG_PASSWORD/PG_DATABASE (or set PG_ENABLE_RUNTIME_CONNECT=true and use connect_db)'
+      );
+    }
+    const conn = await connector.connect(activeConfig);
+    // An unhandled 'error' event would crash the process; on a dropped socket route the teardown
+    // through the shared lifecycle so the next call reconnects cleanly.
+    conn.client.on('error', (err: Error) => {
+      console.error(`[postgres-server] connection error: ${err.message}`);
+      if (connection === conn) {
+        connection = null;
+        void teardown(conn);
+      }
+    });
+    try {
+      await applySessionSettings(conn.client);
+    } catch (err) {
+      await teardown(conn); // never throws, so the original setup error is preserved
+      throw err;
+    }
+    connection = conn;
+    return conn.client;
+  }
+
+  // True when the connection is left inside a transaction (open or aborted). Read from pg's local
+  // ReadyForQuery status - no round-trip; getTransactionStatus lags in @types/pg.
+  function leftInTransaction(c: pg.Client): boolean {
+    const status = (c as unknown as { getTransactionStatus(): string | null }).getTransactionStatus();
+    return status === 'T' || status === 'E';
+  }
+
+  // Run body on the client, serialized; pg errors become a typed failure. A call that left the
+  // connection in a transaction (e.g. a bare BEGIN) is discarded so it can't poison the next call.
+  async function run<T>(body: (c: pg.Client) => Promise<T>): Promise<Result<T>> {
+    return serialized(async () => {
+      let c: pg.Client;
+      try {
+        c = await getClient();
+      } catch (err) {
+        return { ok: false, error: classifyPgError(err) };
+      }
+      const result: Result<T> = await body(c).then(
+        (data) => ({ ok: true, data }),
+        (err) => ({ ok: false, error: classifyPgError(err) })
+      );
+      if (connection !== null && connection.client === c && leftInTransaction(c)) {
+        await discardConnection();
+        // Transactions can't span tool calls, so report that instead of a misleading success; keep a real SQL error.
+        if (result.ok) {
+          return {
+            ok: false,
+            error: { message: 'transaction control is not supported: transactions cannot span tool calls; do not use BEGIN/COMMIT/SAVEPOINT' },
+          };
+        }
+      }
+      return result;
     });
   }
 
-  private async handleConnectDb(args: any) {
-    if (!args.host || !args.user || !args.password || !args.database) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        'Missing required database configuration parameters'
-      );
-    }
+  const guardFailure = (reason: string): Result<never> => ({ ok: false, error: { message: reason } });
 
-    // Close existing connection if any
-    if (this.client) {
-      await this.client.end();
-      this.client = null;
-    }
+  // Idempotent.
+  async function discardConnection(): Promise<void> {
+    const conn = connection;
+    connection = null;
+    if (conn !== null) await teardown(conn);
+  }
 
-    this.config = {
-      host: args.host,
-      port: args.port || 5432,
-      user: args.user,
-      password: args.password,
-      database: args.database,
+  // A read in a rolled-back READ ONLY transaction: the engine refuses any write, even one hidden in
+  // a function/view/rule. BEGIN is awaited, then query and ROLLBACK pipeline into one round-trip.
+  async function readInTransaction(c: pg.Client, sql: string, params: unknown[]): Promise<pg.QueryResult> {
+    await c.query('BEGIN READ ONLY');
+    const [query, rollback] = await Promise.allSettled([
+      c.query(extendedQuery(sql, params)),
+      c.query('ROLLBACK'),
+    ]);
+    if (rollback.status === 'rejected') {
+      // Rollback failed -> session state unknown: drop the connection, report the failure.
+      await discardConnection();
+      throw query.status === 'rejected' ? query.reason : rollback.reason;
+    }
+    if (query.status === 'rejected') throw query.reason;
+    return query.value;
+  }
+
+  function queryData(result: pg.QueryResult): QueryData {
+    const total = result.rowCount ?? result.rows.length;
+    const capped = capBySize(result.rows, activeConfig.maxResultBytes);
+    const returnedRows = capped.rows.length;
+    const budget = activeConfig.maxResultBytes;
+    const hint = !capped.truncated
+      ? undefined
+      : returnedRows === 0
+        ? `no row fits the ~${budget}-byte result budget: select fewer or narrower columns (or raise PG_MAX_RESULT_BYTES)`
+        : `returned ${returnedRows} of ${total} rows (~${budget}-byte budget): add LIMIT/WHERE or select fewer columns`;
+    return {
+      rows: capped.rows,
+      rowCount: total,
+      returnedRows,
+      truncated: capped.truncated,
+      ...(hint !== undefined ? { hint } : {}),
     };
-
-    try {
-      await this.ensureConnection();
-      return {
-        content: [
-          {
-            type: 'text',
-            text: 'Successfully connected to PostgreSQL database',
-          },
-        ],
-      };
-    } catch (error) {
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Failed to connect to database: ${getErrorMessage(error)}`
-      );
-    }
   }
 
-  private async handleQuery(args: any) {
-    await this.ensureConnection();
-
-    if (!args.sql) {
-      throw new McpError(ErrorCode.InvalidParams, 'SQL query is required');
-    }
-
-    if (!args.sql.trim().toUpperCase().startsWith('SELECT')) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        'Only SELECT queries are allowed with query tool'
+  return {
+    query(sql, params) {
+      // Read-only mode wraps the read so the engine refuses any write; write mode trusts the role
+      // and sends it directly in one round-trip.
+      return run(async (c) =>
+        queryData(
+          activeConfig.readOnly
+            ? await readInTransaction(c, sql, params ?? [])
+            : await c.query(extendedQuery(sql, params ?? []))
+        )
       );
-    }
+    },
 
-    try {
-      // Convert ? parameters to $1, $2, etc. if needed
-      const sql = args.sql.includes('?') ? convertToNamedParams(args.sql) : args.sql;
-      const result = await this.client!.query(sql, args.params || []);
-      
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(result.rows, null, 2),
-          },
-        ],
-      };
-    } catch (error) {
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Query execution failed: ${getErrorMessage(error)}`
-      );
-    }
-  }
+    execute(sql, params) {
+      // Always registered for discoverability, but a write is refused here in read-only mode - the
+      // SQL never reaches the database.
+      if (activeConfig.readOnly) {
+        return Promise.resolve(guardFailure('the server is read-only; set PG_ALLOW_WRITE=true to enable writes'));
+      }
+      return run(async (c) => {
+        const result = await c.query(extendedQuery(sql, params ?? []));
+        return { rowCount: result.rowCount, command: result.command };
+      });
+    },
 
-  private async handleExecute(args: any) {
-    await this.ensureConnection();
+    listSchemas() {
+      return run(async (c) => {
+        const result = await c.query<{ schema_name: string }>(
+          'SELECT schema_name FROM information_schema.schemata ORDER BY schema_name'
+        );
+        return { schemas: result.rows.map((r) => r.schema_name) };
+      });
+    },
 
-    if (!args.sql) {
-      throw new McpError(ErrorCode.InvalidParams, 'SQL query is required');
-    }
+    listTables(schema) {
+      return run(async (c) => {
+        const result = await c.query<{ table_name: string }>(
+          'SELECT table_name FROM information_schema.tables WHERE table_schema = $1 ORDER BY table_name',
+          [schema]
+        );
+        return { tables: result.rows.map((r) => r.table_name) };
+      });
+    },
 
-    const sql = args.sql.trim().toUpperCase();
-    if (sql.startsWith('SELECT')) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        'Use query tool for SELECT statements'
-      );
-    }
+    describeTable(schema, table) {
+      return run(async (c) => {
+        const result = await c.query<{
+          column_name: string;
+          data_type: string;
+          is_nullable: string;
+          column_default: string | null;
+          is_primary_key: boolean;
+        }>(
+          // PK from pg_constraint.conkey (information_schema hides it from SELECT-only roles; indkey includes INCLUDE cols).
+          `SELECT c.column_name, c.data_type, c.is_nullable, c.column_default,
+                  COALESCE(pk.is_pk, false) AS is_primary_key
+           FROM information_schema.columns c
+           LEFT JOIN (
+             SELECT a.attname AS column_name, true AS is_pk
+             FROM pg_catalog.pg_constraint con
+             JOIN pg_catalog.pg_class t ON t.oid = con.conrelid
+             JOIN pg_catalog.pg_namespace n ON n.oid = t.relnamespace
+             JOIN pg_catalog.pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = ANY (con.conkey)
+             WHERE con.contype = 'p' AND n.nspname = $1 AND t.relname = $2
+           ) pk ON c.column_name = pk.column_name
+           WHERE c.table_schema = $1 AND c.table_name = $2
+           ORDER BY c.ordinal_position`,
+          [schema, table]
+        );
+        return {
+          columns: result.rows.map((r) => ({
+            column: r.column_name,
+            type: r.data_type,
+            nullable: r.is_nullable === 'YES',
+            default: r.column_default,
+            is_primary_key: r.is_primary_key === true,
+          })),
+        };
+      });
+    },
 
-    try {
-      // Convert ? parameters to $1, $2, etc. if needed
-      const preparedSql = args.sql.includes('?') ? convertToNamedParams(args.sql) : args.sql;
-      const result = await this.client!.query(preparedSql, args.params || []);
-      
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              rowCount: result.rowCount,
-              command: result.command,
-            }, null, 2),
-          },
-        ],
-      };
-    } catch (error) {
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Query execution failed: ${getErrorMessage(error)}`
-      );
-    }
-  }
+    retarget(target) {
+      if (target.port !== undefined && !isValidPort(target.port)) {
+        return Promise.resolve(guardFailure(portRangeError(`invalid port ${target.port}`)));
+      }
+      return serialized(async () => {
+        const previousConfig = activeConfig;
+        // discardConnection clears the ref before closing, so the old connection's error handler
+        // (which checks `connection === conn`) can never null the new one.
+        await discardConnection();
+        activeConfig = { ...activeConfig, connectionString: undefined, host: target.host, port: target.port ?? DEFAULT_PORT, user: target.user, password: target.password, database: target.database };
+        try {
+          await getClient();
+          return { ok: true, data: { host: target.host, database: target.database } };
+        } catch (err) {
+          activeConfig = previousConfig; // roll back so later calls retry the old target
+          connection = null;
+          return { ok: false, error: classifyPgError(err) };
+        }
+      });
+    },
 
-  private async handleListSchemas() {
-    await this.ensureConnection();
-  
-    try {
-      const result = await this.client!.query(`
-        SELECT schema_name
-        FROM information_schema.schemata
-        ORDER BY schema_name
-      `);
-      
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(result.rows, null, 2),
-          },
-        ],
-      };
-    } catch (error) {
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Failed to list schemas: ${getErrorMessage(error)}`
-      );
-    }
-  }
+    close() {
+      // Idempotent: close the current connection, then await any teardown the error handler started
+      // out of band, so the process never exits while a client or SSH tunnel is still closing.
+      return serialized(async () => {
+        await discardConnection();
+        await pendingCleanup;
+      });
+    },
+  };
+}
 
-  private async handleListTables(args: any = {}) {
-    await this.ensureConnection();
-  
-    const schema = args.schema || 'public';
-  
-    try {
-      const result = await this.client!.query(`
-        SELECT table_name
-        FROM information_schema.tables
-        WHERE table_schema = $1
-        ORDER BY table_name
-      `, [schema]);
-      
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(result.rows, null, 2),
-          },
-        ],
-      };
-    } catch (error) {
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Failed to list tables: ${getErrorMessage(error)}`
-      );
-    }
-  }
+// --- tools - the MCP tool surface (thin: validate input, map Result to MCP) ---
 
-  private async handleDescribeTable(args: any) {
-    await this.ensureConnection();
-  
-    if (!args.table) {
-      throw new McpError(ErrorCode.InvalidParams, 'Table name is required');
-    }
-  
-    const schema = args.schema || 'public';
-  
-    try {
-      const result = await this.client!.query(`
-        SELECT 
-          c.column_name, 
-          c.data_type, 
-          c.is_nullable, 
-          c.column_default,
-          CASE 
-            WHEN pk.constraint_type = 'PRIMARY KEY' THEN true 
-            ELSE false 
-          END AS is_primary_key,
-          c.character_maximum_length
-        FROM 
-          information_schema.columns c
-        LEFT JOIN (
-          SELECT 
-            tc.constraint_type, 
-            kcu.column_name, 
-            kcu.table_name,
-            kcu.table_schema
-          FROM 
-            information_schema.table_constraints tc
-          JOIN 
-            information_schema.key_column_usage kcu
-          ON 
-            tc.constraint_name = kcu.constraint_name
-          WHERE 
-            tc.constraint_type = 'PRIMARY KEY'
-        ) pk
-        ON 
-          c.column_name = pk.column_name
-          AND c.table_name = pk.table_name
-          AND c.table_schema = pk.table_schema
-        WHERE 
-          c.table_schema = $1 
-          AND c.table_name = $2
-        ORDER BY 
-          c.ordinal_position
-      `, [schema, args.table]);
-      
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(result.rows, null, 2),
-          },
-        ],
-      };
-    } catch (error) {
-      throw new McpError(
-        ErrorCode.InternalError,
-        `Failed to describe table: ${getErrorMessage(error)}`
-      );
-    }
-  }
+type ToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+};
 
-  async run() {
-    const transport = new StdioServerTransport();
-    await this.server.connect(transport);
-    console.error('PostgreSQL MCP server running on stdio');
+// Compact JSON (no pretty-printing - tokens matter).
+function textResult(payload: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }] };
+}
+
+// An isError result (not a thrown protocol error) so the model can read it and self-correct.
+function errorResult(payload: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(payload) }], isError: true };
+}
+
+const paramsShape = z
+  .array(z.union([z.string(), z.number(), z.boolean(), z.null()]))
+  .optional()
+  .describe('Positional parameter values bound to $1, $2, ... placeholders.');
+
+function reply<T>(result: Result<T>): ToolResult {
+  return result.ok ? textResult(result.data) : errorResult(result.error);
+}
+
+// execute is always registered so writes are discoverable (it refuses in read-only mode); connect_db
+// is gated - an unregistered tool can't be called.
+function registerTools(server: McpServer, db: Database, config: ServerConfig): void {
+  const capHint = `Prefer $1, $2 placeholders with the params array over interpolating values. Results are capped at ~${config.maxResultBytes} bytes; truncated:true means rows were dropped - add LIMIT/WHERE or select fewer columns.`;
+  server.registerTool(
+    'query',
+    {
+      // Mode-aware: engine-enforced read-only, or (with PG_ALLOW_WRITE=true) sent directly and able to write.
+      title: config.readOnly ? 'Run read-only SQL' : 'Run SQL',
+      description: config.readOnly
+        ? 'Run one read-only SQL statement against the connected PostgreSQL database and get rows back as JSON. ' +
+          'Send exactly one statement per call (SELECT, WITH, EXPLAIN, or SHOW). It runs inside an engine-enforced read-only transaction, so any write is refused by the database. ' +
+          'Use this tool for all data reading, aggregation, and query planning. ' +
+          capHint
+        : 'Run one SQL statement against the connected PostgreSQL database and get rows back as JSON. ' +
+          'Because the server was started with PG_ALLOW_WRITE=true, the statement is sent directly and can modify data - use the execute tool for writes and this for reads. Send exactly one statement per call. ' +
+          capHint,
+      inputSchema: {
+        sql: z.string().describe('One SQL statement. Use $1, $2, ... for parameters.'),
+        params: paramsShape,
+      },
+      annotations: { readOnlyHint: config.readOnly, openWorldHint: false },
+    },
+    async ({ sql, params }) => reply(await db.query(sql, params))
+  );
+
+  server.registerTool(
+    'execute',
+    {
+      title: 'Run a write statement',
+      description: config.readOnly
+        ? 'Run a data-modifying SQL statement (INSERT/UPDATE/DELETE or DDL). Currently DISABLED: the server is read-only, so this returns an error and changes nothing. To enable writes, the operator must start the server with PG_ALLOW_WRITE=true.'
+        : 'Run one data-modifying SQL statement - INSERT, UPDATE, DELETE, or DDL like CREATE/ALTER - and get the affected row count back. ' +
+          'Use the query tool for anything that reads. Send exactly one complete statement per call; do not use explicit transaction or session control (BEGIN, COMMIT, SET, ...). ' +
+          'Prefer $1, $2 placeholders with the params array. This tool exists because the server was started with PG_ALLOW_WRITE=true.',
+      inputSchema: {
+        sql: z
+          .string()
+          .describe('One INSERT / UPDATE / DELETE / DDL statement. Use $1, $2, ... for parameters.'),
+        params: paramsShape,
+      },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
+    },
+    async ({ sql, params }) => reply(await db.execute(sql, params))
+  );
+
+  server.registerTool(
+    'list_schemas',
+    {
+      title: 'List schemas',
+      description:
+        'List every schema in the connected database. Start here when exploring an unfamiliar database, then call list_tables for the schema you care about.',
+      inputSchema: {},
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async () => reply(await db.listSchemas())
+  );
+
+  server.registerTool(
+    'list_tables',
+    {
+      title: 'List tables',
+      description:
+        "List all tables in a schema (default: 'public'). Use this before querying tables you have not seen yet, then call describe_table for column details.",
+      inputSchema: {
+        schema: z.string().optional().describe("Schema name (default: 'public')"),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async ({ schema }) => reply(await db.listTables(schema ?? DEFAULT_SCHEMA))
+  );
+
+  server.registerTool(
+    'describe_table',
+    {
+      title: 'Describe a table',
+      description:
+        'Show the structure of one table: column names, data types, nullability, defaults, and primary-key membership. Call this before writing non-trivial queries against a table.',
+      inputSchema: {
+        table: z.string().describe('Table name'),
+        schema: z.string().optional().describe("Schema name (default: 'public')"),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async ({ table, schema }) => reply(await db.describeTable(schema ?? DEFAULT_SCHEMA, table))
+  );
+
+  if (config.allowRuntimeConnect) {
+    server.registerTool(
+      'connect_db',
+      {
+        title: 'Connect to a different database',
+        description:
+          'Switch the server to a different PostgreSQL database at runtime, replacing the current connection. ' +
+          'Only use this when the user explicitly asks to connect elsewhere or the configured connection fails - normal operation uses the connection from the environment. ' +
+          'Read-only mode and the statement timeout are re-applied to the new connection.',
+        inputSchema: {
+          host: z.string().describe('Database host'),
+          port: z.number().optional().describe('Database port (default: 5432)'),
+          user: z.string().describe('Database user'),
+          password: z.string().describe('Database password'),
+          database: z.string().describe('Database name'),
+        },
+        annotations: { readOnlyHint: false, openWorldHint: true },
+      },
+      async ({ host, port, user, password, database }) => {
+        const result = await db.retarget({ host, port, user, password, database });
+        return result.ok
+          ? textResult({ message: 'Successfully connected to PostgreSQL database', ...result.data })
+          : errorResult(result.error);
+      }
+    );
   }
 }
 
-const server = new PostgresServer();
-server.run().catch(console.error);
+// MCP server over one database, plus an awaitable close() for both (server.close alone does not
+// await the db, so a caller could exit before the socket closes).
+export function createApp(
+  config: ServerConfig,
+  connector: Connector = defaultConnector
+): { server: McpServer; close: () => Promise<void> } {
+  const server = new McpServer({ name: 'postgres-server', version: VERSION });
+  const db = createDatabase(config, connector);
+  registerTools(server, db, config);
+  // Also close the db if the transport closes on its own (SDK leaves onclose unset).
+  server.server.onclose = () => void db.close();
+  return {
+    server,
+    close: async () => {
+      try {
+        await server.close();
+      } finally {
+        await db.close(); // idempotent; runs even if server.close threw
+      }
+    },
+  };
+}
+
+export function createServer(
+  config: ServerConfig,
+  connector: Connector = defaultConnector
+): McpServer {
+  return createApp(config, connector).server;
+}
+
+// --- main - stdio transport; only runs when executed directly, never on import ---
+
+// The slice of `process` main() touches - injected so the entry point runs under test.
+export interface ProcessLike {
+  env: Record<string, string | undefined>;
+  on(event: 'SIGINT' | 'SIGTERM', handler: () => void): unknown;
+  stdin: { on(event: 'close', handler: () => void): unknown };
+  exit(code: number): void;
+}
+
+export async function main(proc: ProcessLike, transport: Transport): Promise<void> {
+  const cfg = loadConfig(proc.env);
+  // Load the optional SSH connector (and its ssh2 dependency) only when configured, so the core
+  // never imports it. A direct connection uses the default.
+  const connector = cfg.ssh ? (await import('./ssh-connector.js')).createSshConnector(cfg.ssh) : defaultConnector;
+  const app = createApp(cfg, connector);
+
+  const shutdown = (): void => {
+    app
+      .close()
+      .catch(() => undefined)
+      .finally(() => proc.exit(0));
+  };
+  proc.on('SIGINT', shutdown);
+  proc.on('SIGTERM', shutdown);
+  proc.stdin.on('close', shutdown);
+
+  await app.server.connect(transport);
+  // stdout is the protocol channel - all logging goes to stderr.
+  console.error(
+    `[postgres-server] v${VERSION} running on stdio in ${
+      cfg.readOnly ? 'read-only mode (set PG_ALLOW_WRITE=true to enable writes)' : 'READ-WRITE mode'
+    }${cfg.allowRuntimeConnect ? '; runtime connect_db enabled' : ''}`
+  );
+}
+
+// True when `entry` (process.argv[1]) is this module - directly or through an npm bin symlink.
+export function isEntryPoint(entry: string | undefined, moduleUrl: string): boolean {
+  if (!entry) return false;
+  if (moduleUrl === pathToFileURL(entry).href) return true;
+  try {
+    return moduleUrl === pathToFileURL(realpathSync(entry)).href;
+  } catch {
+    return false;
+  }
+}
+
+export const stdioTransport = (): Transport => new StdioServerTransport();
+
+// Run main() only when this file is the executed entry point - never on import.
+export function bootstrap(
+  entry: string | undefined,
+  moduleUrl: string,
+  proc: ProcessLike,
+  makeTransport: () => Transport
+): void {
+  if (!isEntryPoint(entry, moduleUrl)) return;
+  main(proc, makeTransport()).catch((err) => {
+    console.error('[postgres-server] fatal:', err);
+    proc.exit(1);
+  });
+}
+
+bootstrap(process.argv[1], import.meta.url, process, stdioTransport);

--- a/src/ssh-connector.ts
+++ b/src/ssh-connector.ts
@@ -1,0 +1,283 @@
+/**
+ * Optional SSH-tunnel connector, loaded by main() via dynamic import only when PG_SSH_HOST is set,
+ * so a direct connection pulls neither this module nor its `ssh2` optional dependency. Same Connector
+ * contract as the direct connector; close() releases every resource once, awaiting actual closure.
+ *
+ *   pg.Client -> 127.0.0.1 listener -> ssh2 forwardOut -> SSH bastion -> PostgreSQL
+ *
+ * SSH is pure transport: no SQL and no per-query handshake, and the pg client options come from the
+ * same resolveClientOptions the direct connector uses, so only the transport differs.
+ */
+import net from 'node:net';
+import type { Duplex } from 'node:stream';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import pg from 'pg';
+import { resolveClientOptions, type Connection, type Connector, type ServerConfig, type SshConfig } from './index.js';
+import type { ConnectConfig } from 'ssh2';
+
+// The slice of ssh2's Client used here, typed structurally so tests inject a fake and ssh2 stays a
+// lazy runtime import.
+export interface SshClientLike {
+  forwardOut(srcHost: string, srcPort: number, dstHost: string, dstPort: number, cb: (err: Error | undefined, channel: Duplex) => void): void;
+  end(): void;
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+}
+
+// Injectable boundaries (real ssh2 + pg by default) so tests drive the connector without a bastion.
+export interface SshConnectorDeps {
+  openSsh(config: ConnectConfig): Promise<SshClientLike>;
+  createPgClient(options: pg.ClientConfig): pg.Client;
+}
+
+const defaultDeps: SshConnectorDeps = {
+  async openSsh(config) {
+    const { Client } = await import('ssh2');
+    const client = new Client();
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        client.removeListener('ready', onReady);
+        client.removeListener('error', onFail);
+        client.removeListener('close', onClose);
+        client.removeListener('end', onClose);
+      };
+      const succeed = (): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve();
+      };
+      const failWith = (err: Error): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        try { client.end(); } catch { /* releasing a half-open client */ }
+        reject(err);
+      };
+      const onReady = (): void => succeed();
+      const onFail = (err: unknown): void => failWith(err instanceof Error ? err : new Error(String(err)));
+      // A premature end/close during the handshake clears ssh2's own timer; settling as a failure
+      // here keeps the promise from hanging forever and blocking the database queue.
+      const onClose = (): void => failWith(new Error('SSH connection closed before it became ready'));
+      const setupDeadlineMs = (config.readyTimeout ?? 10000) + 2000; // ready timeout + margin
+      const timer = setTimeout(() => failWith(new Error(`SSH setup timed out after ${setupDeadlineMs}ms`)), setupDeadlineMs);
+      client.once('ready', onReady);
+      client.once('error', onFail);
+      client.once('close', onClose);
+      client.once('end', onClose);
+      client.connect(config);
+    });
+    return client as unknown as SshClientLike;
+  },
+  createPgClient: (options) => new pg.Client(options),
+};
+
+// Fail-closed host-key verification: a pinned SHA256 fingerprint must match, else refuse to connect
+// rather than trust any key (ssh2's default).
+export function buildHostVerifier(sshConfig: SshConfig): (key: Buffer) => boolean {
+  if (sshConfig.fingerprint === undefined) {
+    throw new Error('SSH host-key verification is required: set PG_SSH_FINGERPRINT');
+  }
+  const want = normalizeFingerprint(sshConfig.fingerprint);
+  return (key) => normalizeFingerprint(createHash('sha256').update(key).digest('base64')) === want;
+}
+
+// Ignores the "SHA256:" prefix and base64 "=" padding.
+function normalizeFingerprint(fp: string): string {
+  return fp.replace(/^SHA256:/i, '').replace(/=+$/, '');
+}
+
+// The default key ssh would try, under $HOME (or %USERPROFILE% on Windows): first of id_ed25519 /
+// id_rsa / id_ecdsa that exists, else undefined.
+export function defaultKeyPath(env: NodeJS.ProcessEnv): string | undefined {
+  const home = env.HOME ?? env.USERPROFILE;
+  if (home === undefined || home === '') return undefined;
+  for (const name of ['id_ed25519', 'id_rsa', 'id_ecdsa']) {
+    const path = join(home, '.ssh', name);
+    if (existsSync(path)) return path;
+  }
+  return undefined;
+}
+
+// ssh2 connect options from PG_SSH_*. Auth resolves like ssh: an explicit key, agent, or password
+// wins (in that order); otherwise fall back to a running agent (SSH_AUTH_SOCK), then a default key file.
+export function buildSshConnectConfig(sshConfig: SshConfig, connectTimeoutMs: number, env: NodeJS.ProcessEnv = process.env): ConnectConfig {
+  const config: ConnectConfig = {
+    host: sshConfig.host,
+    port: sshConfig.port,
+    username: sshConfig.user,
+    readyTimeout: connectTimeoutMs,
+    keepaliveInterval: sshConfig.keepaliveIntervalMs,
+    keepaliveCountMax: 3,
+    hostVerifier: buildHostVerifier(sshConfig),
+  };
+  const useKey = (path: string): void => {
+    config.privateKey = readFileSync(path);
+    if (sshConfig.passphrase !== undefined) config.passphrase = sshConfig.passphrase;
+  };
+  if (sshConfig.privateKeyPath !== undefined) {
+    useKey(sshConfig.privateKeyPath);
+  } else if (sshConfig.agent !== undefined) {
+    // 'true' means the ambient agent (SSH_AUTH_SOCK); anything else is a socket/named-pipe path.
+    const agent = sshConfig.agent === 'true' ? env.SSH_AUTH_SOCK : sshConfig.agent;
+    if (agent === undefined || agent === '') {
+      throw new Error('PG_SSH_AGENT=true but SSH_AUTH_SOCK is not set');
+    }
+    config.agent = agent;
+  } else if (sshConfig.password !== undefined) {
+    config.password = sshConfig.password;
+  } else if (env.SSH_AUTH_SOCK !== undefined && env.SSH_AUTH_SOCK !== '') {
+    config.agent = env.SSH_AUTH_SOCK;
+  } else {
+    const keyPath = defaultKeyPath(env);
+    if (keyPath === undefined) {
+      throw new Error('SSH authentication required: set PG_SSH_PRIVATE_KEY, PG_SSH_AGENT, or PG_SSH_PASSWORD, or provide a default key (~/.ssh/id_ed25519) or a running agent (SSH_AUTH_SOCK)');
+    }
+    useKey(keyPath);
+  }
+  return config;
+}
+
+// Keep the ORIGINAL database hostname for SNI and certificate validation, though the socket connects
+// to 127.0.0.1 - else verify-full breaks through the loopback.
+export function sslForTunnel(ssl: pg.ClientConfig['ssl'], realHost: string): { ssl?: pg.ClientConfig['ssl'] } {
+  if (ssl === undefined) return {};
+  if (typeof ssl === 'object') return { ssl: { ...ssl, servername: realHost } };
+  return { ssl };
+}
+
+interface Forwarder {
+  server: net.Server;
+  localPort: number;
+  sockets: Set<net.Socket>;
+}
+
+/**
+ * Loopback listener forwarding each incoming socket through the tunnel. Binds 127.0.0.1:0 (an
+ * OS-assigned free port, never occupied; a plain TCP socket that works on Windows too). When the
+ * tunnel dies it stops accepting and drops live sockets so pg sees the break and reconnects; a
+ * late/failed forward becomes a socket error, never an uncaught exception that crashes the process.
+ */
+function openForwarder(ssh: SshClientLike, target: { host: string; port: number }): Promise<Forwarder> {
+  const sockets = new Set<net.Socket>();
+  let tunnelDown = false;
+  const server = net.createServer((socket) => {
+    if (tunnelDown) {
+      socket.destroy();
+      return;
+    }
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    socket.on('error', () => socket.destroy());
+    try {
+      ssh.forwardOut('127.0.0.1', 0, target.host, target.port, (err, channel) => {
+        if (err !== undefined && err !== null) {
+          socket.destroy(err);
+          return;
+        }
+        channel.on('error', () => socket.destroy());
+        socket.pipe(channel).pipe(socket);
+      });
+    } catch (err) {
+      // forwardOut throws synchronously ("Not connected") if SSH dropped between accept and here.
+      socket.destroy(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+  const onTunnelDown = (): void => {
+    tunnelDown = true;
+    for (const s of sockets) s.destroy();
+    try { server.close(); } catch { /* already closing/closed */ }
+  };
+  ssh.on('error', onTunnelDown);
+  ssh.on('close', onTunnelDown);
+  ssh.on('end', onTunnelDown);
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({ server, localPort: typeof address === 'object' && address !== null ? address.port : 0, sockets });
+    });
+  });
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+// Await the SSH client's actual close (bounded), initiating it if it has not already happened.
+function endSsh(ssh: SshClientLike, alreadyClosed: () => boolean): Promise<void> {
+  if (alreadyClosed()) {
+    try { ssh.end(); } catch { /* no-op on an already-closed client */ }
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, 5000); // safety net: never hang shutdown on a stuck close
+    ssh.on('close', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    try {
+      ssh.end();
+    } catch {
+      clearTimeout(timer);
+      resolve();
+    }
+  });
+}
+
+// One owned Connection whose close() resolves only once pg client, sockets, listener, and SSH have
+// ACTUALLY closed. Idempotent: concurrent/repeat close() calls await the one teardown.
+function ownedConnection(ssh: SshClientLike, server: net.Server, sockets: Set<net.Socket>, client: pg.Client): Connection {
+  let sshClosed = false;
+  ssh.on('close', () => { sshClosed = true; });
+  let closing: Promise<void> | undefined;
+  const teardown = async (): Promise<void> => {
+    const errors: string[] = [];
+    await client.end().catch((e: unknown) => errors.push(String(e)));
+    for (const s of sockets) s.destroy();
+    await closeServer(server);
+    await endSsh(ssh, () => sshClosed);
+    if (errors.length > 0) throw new Error(`ssh connection cleanup failed: ${errors.join('; ')}`);
+  };
+  return {
+    client,
+    close: () => (closing ??= teardown()),
+  };
+}
+
+// Creating the connector opens nothing; each connect() opens a fresh tunnel + pg client and returns
+// one owned Connection. A partial startup failure releases whatever was already opened before rejecting.
+export function createSshConnector(sshConfig: SshConfig, deps: SshConnectorDeps = defaultDeps): Connector {
+  return {
+    async connect(cfg) {
+      const options = resolveClientOptions(cfg);
+      const realHost = options.host ?? 'localhost';
+      const realPort = typeof options.port === 'number' ? options.port : 5432;
+      const sshConf = buildSshConnectConfig(sshConfig, cfg.connectTimeoutMs); // throws before opening anything if misconfigured
+      const ssh = await deps.openSsh(sshConf);
+      try {
+        const { server, localPort, sockets } = await openForwarder(ssh, { host: realHost, port: realPort });
+        try {
+          const client = deps.createPgClient({
+            ...options,
+            host: '127.0.0.1',
+            port: localPort,
+            ...sslForTunnel(options.ssl, realHost),
+          });
+          await client.connect();
+          return ownedConnection(ssh, server, sockets, client);
+        } catch (err) {
+          for (const s of sockets) s.destroy();
+          await closeServer(server);
+          throw err;
+        }
+      } catch (err) {
+        await endSsh(ssh, () => false);
+        throw err;
+      }
+    },
+  };
+}

--- a/test/__snapshots__/toolsurface.test.ts.snap
+++ b/test/__snapshots__/toolsurface.test.ts.snap
@@ -1,0 +1,367 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`tool surface (registration-time gating) > full (write + runtime connect) tool surface matches the snapshot 1`] = `
+{
+  "tools": [
+    {
+      "_meta": undefined,
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": false,
+      },
+      "description": "Run one SQL statement against the connected PostgreSQL database and get rows back as JSON. Because the server was started with PG_ALLOW_WRITE=true, the statement is sent directly and can modify data - use the execute tool for writes and this for reads. Send exactly one statement per call. Prefer $1, $2 placeholders with the params array over interpolating values. Results are capped at ~32768 bytes; truncated:true means rows were dropped - add LIMIT/WHERE or select fewer columns.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "params": {
+            "description": "Positional parameter values bound to $1, $2, ... placeholders.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean",
+                "null",
+              ],
+            },
+            "type": "array",
+          },
+          "sql": {
+            "description": "One SQL statement. Use $1, $2, ... for parameters.",
+            "type": "string",
+          },
+        },
+        "required": [
+          "sql",
+        ],
+        "type": "object",
+      },
+      "name": "query",
+      "title": "Run SQL",
+    },
+    {
+      "_meta": undefined,
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false,
+      },
+      "description": "Run one data-modifying SQL statement - INSERT, UPDATE, DELETE, or DDL like CREATE/ALTER - and get the affected row count back. Use the query tool for anything that reads. Send exactly one complete statement per call; do not use explicit transaction or session control (BEGIN, COMMIT, SET, ...). Prefer $1, $2 placeholders with the params array. This tool exists because the server was started with PG_ALLOW_WRITE=true.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "params": {
+            "description": "Positional parameter values bound to $1, $2, ... placeholders.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean",
+                "null",
+              ],
+            },
+            "type": "array",
+          },
+          "sql": {
+            "description": "One INSERT / UPDATE / DELETE / DDL statement. Use $1, $2, ... for parameters.",
+            "type": "string",
+          },
+        },
+        "required": [
+          "sql",
+        ],
+        "type": "object",
+      },
+      "name": "execute",
+      "title": "Run a write statement",
+    },
+    {
+      "_meta": undefined,
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true,
+      },
+      "description": "List every schema in the connected database. Start here when exploring an unfamiliar database, then call list_tables for the schema you care about.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {},
+        "type": "object",
+      },
+      "name": "list_schemas",
+      "title": "List schemas",
+    },
+    {
+      "_meta": undefined,
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true,
+      },
+      "description": "List all tables in a schema (default: 'public'). Use this before querying tables you have not seen yet, then call describe_table for column details.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "schema": {
+            "description": "Schema name (default: 'public')",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "list_tables",
+      "title": "List tables",
+    },
+    {
+      "_meta": undefined,
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true,
+      },
+      "description": "Show the structure of one table: column names, data types, nullability, defaults, and primary-key membership. Call this before writing non-trivial queries against a table.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "schema": {
+            "description": "Schema name (default: 'public')",
+            "type": "string",
+          },
+          "table": {
+            "description": "Table name",
+            "type": "string",
+          },
+        },
+        "required": [
+          "table",
+        ],
+        "type": "object",
+      },
+      "name": "describe_table",
+      "title": "Describe a table",
+    },
+    {
+      "_meta": undefined,
+      "annotations": {
+        "openWorldHint": true,
+        "readOnlyHint": false,
+      },
+      "description": "Switch the server to a different PostgreSQL database at runtime, replacing the current connection. Only use this when the user explicitly asks to connect elsewhere or the configured connection fails - normal operation uses the connection from the environment. Read-only mode and the statement timeout are re-applied to the new connection.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "database": {
+            "description": "Database name",
+            "type": "string",
+          },
+          "host": {
+            "description": "Database host",
+            "type": "string",
+          },
+          "password": {
+            "description": "Database password",
+            "type": "string",
+          },
+          "port": {
+            "description": "Database port (default: 5432)",
+            "type": "number",
+          },
+          "user": {
+            "description": "Database user",
+            "type": "string",
+          },
+        },
+        "required": [
+          "host",
+          "user",
+          "password",
+          "database",
+        ],
+        "type": "object",
+      },
+      "name": "connect_db",
+      "title": "Connect to a different database",
+    },
+  ],
+}
+`;
+
+exports[`tool surface (registration-time gating) > read-only (default) tool surface matches the snapshot 1`] = `
+{
+  "tools": [
+    {
+      "_meta": undefined,
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true,
+      },
+      "description": "Run one read-only SQL statement against the connected PostgreSQL database and get rows back as JSON. Send exactly one statement per call (SELECT, WITH, EXPLAIN, or SHOW). It runs inside an engine-enforced read-only transaction, so any write is refused by the database. Use this tool for all data reading, aggregation, and query planning. Prefer $1, $2 placeholders with the params array over interpolating values. Results are capped at ~32768 bytes; truncated:true means rows were dropped - add LIMIT/WHERE or select fewer columns.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "params": {
+            "description": "Positional parameter values bound to $1, $2, ... placeholders.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean",
+                "null",
+              ],
+            },
+            "type": "array",
+          },
+          "sql": {
+            "description": "One SQL statement. Use $1, $2, ... for parameters.",
+            "type": "string",
+          },
+        },
+        "required": [
+          "sql",
+        ],
+        "type": "object",
+      },
+      "name": "query",
+      "title": "Run read-only SQL",
+    },
+    {
+      "_meta": undefined,
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false,
+      },
+      "description": "Run a data-modifying SQL statement (INSERT/UPDATE/DELETE or DDL). Currently DISABLED: the server is read-only, so this returns an error and changes nothing. To enable writes, the operator must start the server with PG_ALLOW_WRITE=true.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "params": {
+            "description": "Positional parameter values bound to $1, $2, ... placeholders.",
+            "items": {
+              "type": [
+                "string",
+                "number",
+                "boolean",
+                "null",
+              ],
+            },
+            "type": "array",
+          },
+          "sql": {
+            "description": "One INSERT / UPDATE / DELETE / DDL statement. Use $1, $2, ... for parameters.",
+            "type": "string",
+          },
+        },
+        "required": [
+          "sql",
+        ],
+        "type": "object",
+      },
+      "name": "execute",
+      "title": "Run a write statement",
+    },
+    {
+      "_meta": undefined,
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true,
+      },
+      "description": "List every schema in the connected database. Start here when exploring an unfamiliar database, then call list_tables for the schema you care about.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {},
+        "type": "object",
+      },
+      "name": "list_schemas",
+      "title": "List schemas",
+    },
+    {
+      "_meta": undefined,
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true,
+      },
+      "description": "List all tables in a schema (default: 'public'). Use this before querying tables you have not seen yet, then call describe_table for column details.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "schema": {
+            "description": "Schema name (default: 'public')",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "name": "list_tables",
+      "title": "List tables",
+    },
+    {
+      "_meta": undefined,
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true,
+      },
+      "description": "Show the structure of one table: column names, data types, nullability, defaults, and primary-key membership. Call this before writing non-trivial queries against a table.",
+      "execution": {
+        "taskSupport": "forbidden",
+      },
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "schema": {
+            "description": "Schema name (default: 'public')",
+            "type": "string",
+          },
+          "table": {
+            "description": "Table name",
+            "type": "string",
+          },
+        },
+        "required": [
+          "table",
+        ],
+        "type": "object",
+      },
+      "name": "describe_table",
+      "title": "Describe a table",
+    },
+  ],
+}
+`;

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -1,0 +1,569 @@
+// Database lifecycle on a fake pg client: lazy connect, the dropped-socket error handler, cleanup on
+// connect failure, connect_db swap-with-rollback - failure modes awkward to provoke against a real server.
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type pg from 'pg';
+import { createApp, createDatabase, createServer, loadConfig, type Connection, type Connector, type ServerConfig } from '../src/index.js';
+
+interface FakeOptions {
+  connectError?: Error;
+  endError?: Error;
+  rollbackError?: Error;
+  beginError?: Error;
+  queryError?: Error; // thrown for a user query whose text contains "will_fail"
+  settingsError?: Error; // thrown while applying session settings (the set_config query)
+  superuser?: 'on' | 'off' | 'throw';
+}
+
+class FakeClient extends EventEmitter {
+  readonly queries: string[] = [];
+  readonly calls: Array<{ text: string; values: unknown[] }> = [];
+  ended = false;
+  connectCount = 0;
+  private tx: 'I' | 'T' | 'E' = 'I'; // ReadyForQuery status, like a real pg client
+  constructor(private readonly opts: FakeOptions = {}) {
+    super();
+  }
+  getTransactionStatus(): string {
+    return this.tx;
+  }
+  async connect(): Promise<void> {
+    this.connectCount++;
+    // A real pg client rejects a second connect - the contract getClient must not violate.
+    if (this.connectCount > 1) throw new Error('Client has already been connected. You cannot reuse a client.');
+    if (this.opts.connectError) throw this.opts.connectError;
+  }
+  async end(): Promise<void> {
+    this.ended = true;
+    if (this.opts.endError) throw this.opts.endError;
+  }
+  async query(cfg: string | { text: string; values?: unknown[] }, values: unknown[] = []): Promise<{ rows: unknown[]; rowCount: number; command: string }> {
+    const text = typeof cfg === 'string' ? cfg : cfg.text;
+    this.queries.push(text);
+    this.calls.push({ text, values: typeof cfg === 'string' ? values : cfg.values ?? [] });
+    if (/^\s*BEGIN/i.test(text)) this.tx = 'T';
+    else if (/^\s*(ROLLBACK|COMMIT|END|ABORT)/i.test(text)) this.tx = 'I';
+    if (this.opts.settingsError && /set_config/.test(text)) throw this.opts.settingsError;
+    if (text === 'BEGIN READ ONLY' && this.opts.beginError) throw this.opts.beginError;
+    if (text === 'ROLLBACK' && this.opts.rollbackError) throw this.opts.rollbackError;
+    if (this.opts.queryError && /will_fail/.test(text)) {
+      this.tx = 'E'; // a failed statement leaves the transaction aborted
+      throw this.opts.queryError;
+    }
+    if (/is_superuser/.test(text)) {
+      if (this.opts.superuser === 'throw') throw new Error('permission denied for current_setting');
+      return { rows: [{ is_superuser: this.opts.superuser ?? 'off' }], rowCount: 1, command: 'SELECT' };
+    }
+    return { rows: [{ ok: 1 }], rowCount: 1, command: 'SELECT' };
+  }
+}
+
+// Connect a fake per the Connector contract: on failure end the half-open client (swallowing that
+// error) and rethrow the original, so the connect error - not a cleanup error - propagates.
+async function connectFake(client: FakeClient): Promise<Connection> {
+  const c = client as unknown as pg.Client;
+  try {
+    await c.connect();
+  } catch (err) {
+    await c.end().catch(() => undefined);
+    throw err;
+  }
+  return { client: c, close: () => client.end().catch(() => undefined) };
+}
+
+// Hands out pre-built fakes in order and records the config it was given; close() ends the fake.
+function factoryOf(...clients: FakeClient[]): { connector: Connector; configs: ServerConfig[] } {
+  const configs: ServerConfig[] = [];
+  const connector: Connector = {
+    connect: (cfg) => {
+      configs.push(cfg);
+      const next = clients.shift();
+      if (!next) throw new Error('connector called more times than expected');
+      return connectFake(next);
+    },
+  };
+  return { connector, configs };
+}
+
+// A connector backed by a single fake client.
+function connectorFor(client: FakeClient): Connector {
+  return { connect: () => connectFake(client) };
+}
+
+// Connects the fake but hands back a custom close(), for probing teardown (async cleanup that may reject).
+function connectorWithClose(client: FakeClient, close: () => Promise<void>): Connector {
+  return {
+    connect: async () => {
+      await (client as unknown as pg.Client).connect();
+      return { client: client as unknown as pg.Client, close };
+    },
+  };
+}
+
+async function openServer(config: ServerConfig, connector: Connector) {
+  const server = createServer(config, connector);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new McpClient({ name: 'connection-test', version: '0.0.0' });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  const call = async (name: string, args: Record<string, unknown> = {}) => {
+    const result = await client.callTool({ name, arguments: args });
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    return { isError: result.isError === true, payload: JSON.parse(text) as Record<string, unknown> };
+  };
+  return {
+    call,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+const URL = 'postgres://u:p@db.example.com:5432/app';
+
+describe('getClient: nothing configured', () => {
+  it('returns an isError result naming every way to configure, without calling the connector', async () => {
+    const { connector, configs } = factoryOf();
+    const { call, close } = await openServer(loadConfig({}), connector);
+    try {
+      const r = await call('query', { sql: 'SELECT 1' });
+      expect(r.isError).toBe(true);
+      expect(r.payload.message).toMatch(/no database configured/);
+      expect(r.payload.message).toMatch(/DATABASE_URL/);
+      expect(r.payload.message).toMatch(/PG_ENABLE_RUNTIME_CONNECT/);
+      expect(configs).toHaveLength(0);
+    } finally {
+      await close();
+    }
+  });
+
+  it.each([
+    ['PG_HOST', { PG_HOST: 'h' }],
+    ['PG_USER', { PG_USER: 'u' }],
+    ['PG_DATABASE', { PG_DATABASE: 'd' }],
+  ])('any single %s is enough to attempt a connection', async (_name, env) => {
+    const { connector, configs } = factoryOf(new FakeClient());
+    const { call, close } = await openServer(loadConfig(env), connector);
+    try {
+      const r = await call('query', { sql: 'SELECT 1' });
+      expect(r.isError).toBe(false);
+      expect(configs).toHaveLength(1);
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('Database read routing', () => {
+  it('read-only mode wraps the read in a rolled-back READ ONLY transaction, params bound as values', async () => {
+    const fake = new FakeClient();
+    const db = createDatabase(loadConfig({ DATABASE_URL: URL }), connectorFor(fake));
+    await db.query('SELECT 1'); // one-time connection setup
+    fake.calls.length = 0;
+    const value = "'; COMMIT; DELETE FROM users; --";
+    const result = await db.query('SELECT $1 AS value', [value]);
+    expect(result.ok).toBe(true);
+    expect(fake.calls.map((c) => c.text)).toEqual(['BEGIN READ ONLY', 'SELECT $1 AS value', 'ROLLBACK']);
+    // the value is bound, never spliced into the SQL text.
+    expect(fake.calls[1]).toEqual({ text: 'SELECT $1 AS value', values: [value] });
+    await db.close();
+  });
+
+  it('write mode (PG_ALLOW_WRITE=true) sends the read directly, no transaction wrapping', async () => {
+    const fake = new FakeClient();
+    const db = createDatabase(loadConfig({ DATABASE_URL: URL, PG_ALLOW_WRITE: 'true' }), connectorFor(fake));
+    await db.query('SELECT 1'); // one-time connection setup
+    fake.calls.length = 0;
+    await db.query('SELECT id FROM users WHERE id = $1', [7]);
+    expect(fake.calls.map((c) => c.text)).toEqual(['SELECT id FROM users WHERE id = $1']);
+    await db.close();
+  });
+
+  it('read-only mode refuses execute without opening a connection or sending the write', async () => {
+    const connect = vi.fn();
+    const db = createDatabase(loadConfig({ DATABASE_URL: URL }), { connect }); // read-only by default
+    const r = await db.execute('INSERT INTO t (x) VALUES (1)');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(String(r.error.message)).toMatch(/read-only|PG_ALLOW_WRITE/);
+    expect(connect).not.toHaveBeenCalled(); // never even connected
+    await db.close();
+  });
+
+  it('does not dispatch the read when BEGIN READ ONLY fails', async () => {
+    const fake = new FakeClient({ beginError: new Error('cannot begin') });
+    const db = createDatabase(loadConfig({ DATABASE_URL: URL }), connectorFor(fake));
+    expect((await db.query('SELECT id FROM users')).ok).toBe(false);
+    expect(fake.queries).not.toContain('SELECT id FROM users');
+    await db.close();
+  });
+
+  it('discards a connection left inside a transaction, so the next call is independent', async () => {
+    const first = new FakeClient();
+    const second = new FakeClient();
+    const { connector } = factoryOf(first, second);
+    const db = createDatabase(loadConfig({ DATABASE_URL: URL, PG_ALLOW_WRITE: 'true' }), connector);
+    // A bare BEGIN leaves the connection in a transaction: reported as an error, not a false success.
+    const begin = await db.execute('BEGIN');
+    expect(begin.ok).toBe(false);
+    if (!begin.ok) expect(begin.error.message).toMatch(/transaction control is not supported/);
+    expect(first.ended).toBe(true); // discarded rather than reused
+    // The next call reconnects on a fresh client - no leaked transaction state.
+    const r = await db.query('SELECT 1');
+    expect(r.ok).toBe(true);
+    expect(second.queries).toContain('SELECT 1');
+    await db.close();
+  });
+
+  it('discards a connection left in an aborted transaction (status E) after a failed statement', async () => {
+    const first = new FakeClient({ queryError: Object.assign(new Error('boom'), { code: '25P02' }) });
+    const second = new FakeClient();
+    const { connector } = factoryOf(first, second);
+    const db = createDatabase(loadConfig({ DATABASE_URL: URL, PG_ALLOW_WRITE: 'true' }), connector);
+    const failed = await db.execute('will_fail');
+    expect(failed.ok).toBe(false);
+    if (!failed.ok) expect(failed.error.code).toBe('25P02'); // the real SQL error is preserved, not overridden
+    expect(first.ended).toBe(true); // discarded, not reused
+    expect((await db.query('SELECT 1')).ok).toBe(true); // fresh client
+    await db.close();
+  });
+});
+
+describe('getClient: connect failure', () => {
+  it('ends the half-open client and reports the connect error', async () => {
+    const fake = new FakeClient({ connectError: Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }) });
+    const { connector } = factoryOf(fake);
+    const { call, close } = await openServer(loadConfig({ DATABASE_URL: URL }), connector);
+    try {
+      const r = await call('query', { sql: 'SELECT 1' });
+      expect(r.isError).toBe(true);
+      expect(r.payload.code).toBe('ECONNREFUSED');
+      expect(r.payload.hint).toMatch(/PG_HOST/);
+      expect(fake.ended).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it('still reports the connect error when end() itself throws', async () => {
+    const fake = new FakeClient({ connectError: new Error('refused'), endError: new Error('socket gone') });
+    const { connector } = factoryOf(fake);
+    const { call, close } = await openServer(loadConfig({ DATABASE_URL: URL }), connector);
+    try {
+      const r = await call('query', { sql: 'SELECT 1' });
+      expect(r.isError).toBe(true);
+      expect(r.payload.message).toBe('refused');
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('connector lifecycle contract', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('does not reconnect a client the connector already connected (connect exactly once)', async () => {
+    const fake = new FakeClient();
+    const db = createDatabase(loadConfig({ DATABASE_URL: URL }), connectorFor(fake));
+    const r = await db.query('SELECT 1'); // getClient must NOT call connect() a second time
+    expect(r.ok).toBe(true); // else the fake throws "already been connected"
+    await db.query('SELECT 2'); // reuses the live connection
+    expect(fake.connectCount).toBe(1);
+    await db.close();
+  });
+
+  it('reports the setup error even when the ensuing cleanup fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const fake = new FakeClient({ settingsError: new Error('cannot set statement_timeout') });
+    // close() rejects: it must not replace the original setup error.
+    const db = createDatabase(loadConfig({ DATABASE_URL: URL }), connectorWithClose(fake, () => Promise.reject(new Error('tunnel close failed'))));
+    const r = await db.query('SELECT 1');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toBe('cannot set statement_timeout');
+    await db.close();
+  });
+
+  it('awaits an error-triggered teardown at close() and logs its failure instead of throwing', async () => {
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const fake = new FakeClient();
+    let closeFinished = false;
+    // Async cleanup that only settles on a later macrotask, then rejects (like an SSH tunnel teardown).
+    const db = createDatabase(
+      loadConfig({ DATABASE_URL: URL }),
+      connectorWithClose(fake, () => new Promise((_, reject) => setImmediate(() => {
+        closeFinished = true;
+        reject(new Error('tunnel close failed'));
+      })))
+    );
+    await db.query('SELECT 1'); // opens the connection
+    fake.emit('error', new Error('server closed the connection unexpectedly')); // out-of-band drop
+    await db.close(); // must await the in-flight teardown, not exit mid-cleanup
+    expect(closeFinished).toBe(true);
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/connection cleanup failed: tunnel close failed/));
+  });
+});
+
+describe('session settings', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('applies the timeout and warns when connected as a superuser', async () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const fake = new FakeClient({ superuser: 'on' });
+    const { connector } = factoryOf(fake);
+    const { call, close } = await openServer(loadConfig({ DATABASE_URL: URL, PG_STATEMENT_TIMEOUT: '1500' }), connector);
+    try {
+      await call('query', { sql: 'SELECT 1' });
+      // statement_timeout and idle_in_transaction_session_timeout are set via a parameterized
+      // set_config, not interpolated SQL.
+      expect(fake.calls).toContainEqual({
+        text: 'SELECT set_config($1, $3, false), set_config($2, $3, false)',
+        values: ['statement_timeout', 'idle_in_transaction_session_timeout', '1500'],
+      });
+      // Read-only is enforced by the engine (BEGIN READ ONLY), never as a session-level
+      // SET - a session default would leak across PgBouncer transaction-pooled backends.
+      expect(fake.queries.some((q) => /SET default_transaction_read_only/.test(q))).toBe(false);
+      await call('query', { sql: 'SELECT id FROM users' });
+      expect(fake.queries).toContain('BEGIN READ ONLY');
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/connected as a superuser/));
+    } finally {
+      await close();
+    }
+  });
+
+  it('treats the superuser check as advisory: a failing check does not fail the connection', async () => {
+    const fake = new FakeClient({ superuser: 'throw' });
+    const { connector } = factoryOf(fake);
+    const { call, close } = await openServer(loadConfig({ DATABASE_URL: URL }), connector);
+    try {
+      const r = await call('query', { sql: 'SELECT 1' });
+      expect(r.isError).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+
+  it('never sets a session read-only flag, and skips the superuser check in write mode', async () => {
+    const fake = new FakeClient({ superuser: 'on' });
+    const { connector } = factoryOf(fake);
+    const { call, close } = await openServer(loadConfig({ DATABASE_URL: URL, PG_ALLOW_WRITE: 'true' }), connector);
+    try {
+      await call('query', { sql: 'SELECT 1' });
+      expect(fake.queries.some((q) => /SET default_transaction_read_only/.test(q))).toBe(false);
+      expect(fake.queries.some((q) => /is_superuser/.test(q))).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('dropped connection', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("an 'error' event logs, drops the client, and the next call reconnects", async () => {
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const first = new FakeClient();
+    const second = new FakeClient();
+    const { connector, configs } = factoryOf(first, second);
+    const { call, close } = await openServer(loadConfig({ DATABASE_URL: URL }), connector);
+    try {
+      await call('query', { sql: 'SELECT 1' });
+      expect(configs).toHaveLength(1);
+      first.emit('error', new Error('server closed the connection unexpectedly'));
+      expect(log).toHaveBeenCalledWith(expect.stringMatching(/connection error: server closed/));
+      const r = await call('query', { sql: 'SELECT 1' });
+      expect(r.isError).toBe(false);
+      expect(configs).toHaveLength(2);
+    } finally {
+      await close();
+    }
+  });
+
+  it("an 'error' event from a client that was already replaced does not drop the live one", async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const first = new FakeClient();
+    const second = new FakeClient();
+    const { connector, configs } = factoryOf(first, second);
+    const env = { DATABASE_URL: URL, PG_ENABLE_RUNTIME_CONNECT: 'true' };
+    const { call, close } = await openServer(loadConfig(env), connector);
+    try {
+      await call('query', { sql: 'SELECT 1' });
+      await call('connect_db', { host: 'other', user: 'u', password: 'p', database: 'd' });
+      expect(first.ended).toBe(true);
+      first.emit('error', new Error('late error from the old socket'));
+      await call('query', { sql: 'SELECT 1' });
+      expect(configs).toHaveLength(2); // no third client: `second` stayed live
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('connect_db (reconnect)', () => {
+  it('as the first call: no previous client to close, defaults the port, re-applies session settings', async () => {
+    const fake = new FakeClient();
+    const { connector, configs } = factoryOf(fake);
+    const env = { DATABASE_URL: URL, PG_ENABLE_RUNTIME_CONNECT: 'true' };
+    const { call, close } = await openServer(loadConfig(env), connector);
+    try {
+      const r = await call('connect_db', { host: 'other', user: 'u2', password: 'p2', database: 'd2' });
+      expect(r.isError).toBe(false);
+      expect(r.payload).toMatchObject({ host: 'other', database: 'd2' });
+      expect(configs[0]).toMatchObject({ host: 'other', port: 5432, user: 'u2', database: 'd2', readOnly: true });
+      expect(configs[0].connectionString).toBeUndefined();
+      // Session settings re-applied on the new connection (statement_timeout);
+      // read-only is per-query, never a leaky session-level SET.
+      expect(fake.calls.some((c) => c.values[0] === 'statement_timeout')).toBe(true);
+      expect(fake.queries.some((q) => /SET default_transaction_read_only/.test(q))).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+
+  it('honours an explicit port and closes the previous client', async () => {
+    const first = new FakeClient();
+    const second = new FakeClient();
+    const { connector, configs } = factoryOf(first, second);
+    const env = { DATABASE_URL: URL, PG_ENABLE_RUNTIME_CONNECT: 'true' };
+    const { call, close } = await openServer(loadConfig(env), connector);
+    try {
+      await call('query', { sql: 'SELECT 1' });
+      const r = await call('connect_db', { host: 'other', port: 6543, user: 'u', password: 'p', database: 'd' });
+      expect(r.isError).toBe(false);
+      expect(first.ended).toBe(true);
+      expect(configs[1].port).toBe(6543);
+    } finally {
+      await close();
+    }
+  });
+
+  it('on failure rolls back to the previous target, even when closing the old client throws', async () => {
+    const first = new FakeClient({ endError: new Error('already gone') });
+    const bad = new FakeClient({ connectError: Object.assign(new Error('auth failed'), { code: '28P01' }) });
+    const retry = new FakeClient();
+    const { connector, configs } = factoryOf(first, bad, retry);
+    const env = { DATABASE_URL: URL, PG_ENABLE_RUNTIME_CONNECT: 'true' };
+    const { call, close } = await openServer(loadConfig(env), connector);
+    try {
+      await call('query', { sql: 'SELECT 1' });
+      const r = await call('connect_db', { host: 'bad', user: 'u', password: 'p', database: 'd' });
+      expect(r.isError).toBe(true);
+      expect(r.payload.code).toBe('28P01');
+      expect(r.payload.hint).toMatch(/PG_USER/);
+      // The next call reconnects to the ORIGINAL target, not the bad one.
+      const again = await call('query', { sql: 'SELECT 1' });
+      expect(again.isError).toBe(false);
+      expect(configs[2].connectionString).toBe(URL);
+      expect(configs[2].host).toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  // Sibling of the PG_PORT range check: pg wraps an out-of-range port to a
+  // random one, so the connect would hang the whole queue without this guard.
+  it.each([999999, 0, -1, 70000])('rejects an out-of-range connect_db port %i without touching the connector', async (port) => {
+    const first = new FakeClient();
+    const { connector, configs } = factoryOf(first);
+    const env = { DATABASE_URL: URL, PG_ENABLE_RUNTIME_CONNECT: 'true' };
+    const { call, close } = await openServer(loadConfig(env), connector);
+    try {
+      await call('query', { sql: 'SELECT 1' }); // opens `first`
+      const r = await call('connect_db', { host: 'h', port, user: 'u', password: 'p', database: 'd' });
+      expect(r.isError).toBe(true);
+      expect(r.payload.message).toMatch(/invalid port/);
+      expect(configs).toHaveLength(1); // no second client was ever constructed
+      const again = await call('query', { sql: 'SELECT 1' }); // old connection still serves
+      expect(again.isError).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+
+  it('server shutdown closes the database client (no leaked session)', async () => {
+    const fake = new FakeClient();
+    const { connector } = factoryOf(fake);
+    const { call, close } = await openServer(loadConfig({ DATABASE_URL: URL }), connector);
+    await call('query', { sql: 'SELECT 1' }); // opens `fake`
+    expect(fake.ended).toBe(false);
+    await close(); // client.close() + server.close() -> conn.close()
+    expect(fake.ended).toBe(true);
+  });
+});
+
+describe('Database.query rollback failure', () => {
+  const cfg = () => loadConfig({ DATABASE_URL: URL });
+
+  it('reports failure and discards the client when the read rollback fails', async () => {
+    const poisoned = new FakeClient({ rollbackError: new Error('rollback failed') });
+    const fresh = new FakeClient();
+    const { connector, configs } = factoryOf(poisoned, fresh);
+    const db = createDatabase(cfg(), connector);
+
+    const r = await db.query('SELECT id FROM users');
+    expect(r.ok).toBe(false); // not a maybe-tampered success
+    expect(configs).toHaveLength(1);
+    expect(poisoned.ended).toBe(true); // discarded client was closed, not leaked
+
+    // The poisoned client was discarded: the next call builds a fresh one.
+    const again = await db.query('SELECT 1');
+    expect(again.ok).toBe(true);
+    expect(configs).toHaveLength(2);
+  });
+
+  it('reports the query error (not the rollback error) when both fail, and discards the client', async () => {
+    const queryErr = Object.assign(new Error('boom'), { code: '42P01' });
+    const poisoned = new FakeClient({ queryError: queryErr, rollbackError: new Error('rollback failed') });
+    const db = createDatabase(cfg(), connectorFor(poisoned));
+    const r = await db.query('SELECT will_fail');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('42P01'); // original query error wins over the rollback error
+    expect(poisoned.ended).toBe(true); // client discarded, not leaked
+  });
+});
+
+describe('createApp.close', () => {
+  it('awaits database cleanup, not only server.close', async () => {
+    const fake = new FakeClient();
+    const app = createApp(loadConfig({ DATABASE_URL: URL }), connectorFor(fake));
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const mcp = new McpClient({ name: 'app-close-test', version: '0.0.0' });
+    await app.server.connect(serverTransport);
+    await mcp.connect(clientTransport);
+    await mcp.callTool({ name: 'query', arguments: { sql: 'SELECT 1' } }); // lazily opens the db client
+    await app.close();
+    expect(fake.ended).toBe(true); // close() resolved only after db cleanup ran
+    await mcp.close().catch(() => undefined);
+  });
+});
+
+describe('Database.close', () => {
+  const cfg = () => loadConfig({ DATABASE_URL: URL });
+
+  it('ends the client, is idempotent, and swallows an end() that throws', async () => {
+    const fake = new FakeClient({ endError: new Error('socket gone') });
+    const db = createDatabase(cfg(), connectorFor(fake));
+    await db.query('SELECT 1'); // opens the client
+    await db.close(); // end() throws internally; must not reject
+    expect(fake.ended).toBe(true);
+    await db.close(); // idempotent: nothing left to end
+  });
+
+  it('close() with no open client is a no-op', async () => {
+    const db = createDatabase(cfg(), connectorFor(new FakeClient()));
+    await expect(db.close()).resolves.toBeUndefined();
+  });
+});
+
+describe('Database does not expose mutable configuration', () => {
+  it('has no config surface a caller could mutate to flip readOnly', () => {
+    const db = createDatabase(loadConfig({ DATABASE_URL: URL }), connectorFor(new FakeClient()));
+    // The concrete pg.Client, the target, and the read-only policy stay inside
+    // the implementation; the interface is domain operations only.
+    expect(Object.keys(db).sort()).toEqual(
+      ['close', 'describeTable', 'execute', 'listSchemas', 'listTables', 'query', 'retarget'].sort()
+    );
+    expect((db as Record<string, unknown>).config).toBeUndefined();
+  });
+});

--- a/test/entrypoint.test.ts
+++ b/test/entrypoint.test.ts
@@ -1,0 +1,157 @@
+// Entry point: main(), isEntryPoint(), bootstrap(). main() takes process + transport as args, so the
+// startup path (config, signal handlers, stderr banner, shutdown->exit) runs over an in-memory transport.
+import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { bootstrap, isEntryPoint, main, stdioTransport, type ProcessLike } from '../src/index.js';
+
+// A ProcessLike that records handlers and resolves a promise on exit().
+function fakeProcess(env: Record<string, string> = {}) {
+  const handlers: Record<string, () => void> = {};
+  let resolveExit!: (code: number) => void;
+  const exited = new Promise<number>((resolve) => (resolveExit = resolve));
+  const proc: ProcessLike = {
+    env,
+    on: (event, handler) => (handlers[event] = handler),
+    stdin: { on: (event, handler) => (handlers[`stdin:${event}`] = handler) },
+    exit: (code) => resolveExit(code),
+  };
+  return { proc, handlers, exited };
+}
+
+describe('main', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('serves the tool surface from env config, logs a read-only banner, and exits 0 on SIGINT', async () => {
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { proc, handlers, exited } = fakeProcess({ DATABASE_URL: 'postgres://u:p@h:5432/d' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await main(proc, serverTransport);
+
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/^\[postgres-server\] v\d+\.\d+\.\d+ running on stdio in read-only mode/));
+    expect(Object.keys(handlers).sort()).toEqual(['SIGINT', 'SIGTERM', 'stdin:close']);
+
+    const client = new McpClient({ name: 'entrypoint-test', version: '0.0.0' });
+    await client.connect(clientTransport);
+    const tools = (await client.listTools()).tools.map((t) => t.name).sort();
+    expect(tools).toEqual(['describe_table', 'execute', 'list_schemas', 'list_tables', 'query']);
+    await client.close();
+
+    handlers.SIGINT();
+    await expect(exited).resolves.toBe(0);
+  });
+
+  it('logs READ-WRITE and runtime connect in the banner when both are enabled, and exits 0 when stdin closes', async () => {
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { proc, handlers, exited } = fakeProcess({
+      DATABASE_URL: 'postgres://u:p@h:5432/d',
+      PG_ALLOW_WRITE: 'true',
+      PG_ENABLE_RUNTIME_CONNECT: 'true',
+    });
+    const [, serverTransport] = InMemoryTransport.createLinkedPair();
+    await main(proc, serverTransport);
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/READ-WRITE mode; runtime connect_db enabled$/));
+    handlers['stdin:close']();
+    await expect(exited).resolves.toBe(0);
+  });
+
+  it('selects the SSH connector when PG_SSH_HOST is set, still serving the tool surface', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    // PG_SSH_HOST routes through the optional ssh-connector (loaded lazily); listing tools never
+    // opens the tunnel, so no bastion is needed to prove main wires the connector in.
+    const { proc, handlers, exited } = fakeProcess({ DATABASE_URL: 'postgres://u:p@h:5432/d', PG_SSH_HOST: 'bastion', PG_SSH_FINGERPRINT: 'SHA256:x' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await main(proc, serverTransport);
+    const client = new McpClient({ name: 'entrypoint-ssh-test', version: '0.0.0' });
+    await client.connect(clientTransport);
+    expect((await client.listTools()).tools.map((t) => t.name)).toContain('query');
+    await client.close();
+    handlers.SIGINT();
+    await expect(exited).resolves.toBe(0);
+  });
+
+  it('still exits 0 when closing the transport fails (SIGTERM path)', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { proc, handlers, exited } = fakeProcess({ DATABASE_URL: 'postgres://u:p@h:5432/d' });
+    const brokenTransport: Transport = {
+      start: async () => undefined,
+      send: async () => undefined,
+      close: async () => {
+        throw new Error('close failed');
+      },
+    };
+    await main(proc, brokenTransport);
+    handlers.SIGTERM();
+    await expect(exited).resolves.toBe(0);
+  });
+});
+
+describe('isEntryPoint', () => {
+  // realpath: on macOS tmpdir is itself a symlink, and import.meta.url is always the resolved path.
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'mcp-entry-')));
+  const real = join(dir, 'index.js');
+  const link = join(dir, 'mcp-postgres'); // what an npm bin stub looks like
+  writeFileSync(real, '');
+  symlinkSync(real, link);
+
+  it('is false without an argv[1]', () => {
+    expect(isEntryPoint(undefined, pathToFileURL(real).href)).toBe(false);
+    expect(isEntryPoint('', pathToFileURL(real).href)).toBe(false);
+  });
+
+  it('is true when argv[1] is the module itself', () => {
+    expect(isEntryPoint(real, pathToFileURL(real).href)).toBe(true);
+  });
+
+  it('is true when argv[1] is a symlink to the module (npm bin stub)', () => {
+    expect(isEntryPoint(link, pathToFileURL(real).href)).toBe(true);
+  });
+
+  it('is false for another existing file, and for a path that does not exist', () => {
+    expect(isEntryPoint(real, 'file:///somewhere/else.js')).toBe(false);
+    expect(isEntryPoint(join(dir, 'missing.js'), pathToFileURL(real).href)).toBe(false);
+  });
+
+  it('cleanup', () => rmSync(dir, { recursive: true, force: true }));
+});
+
+describe('bootstrap', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('does nothing when the module is merely imported', () => {
+    const { proc, handlers } = fakeProcess();
+    const makeTransport = vi.fn<() => Transport>();
+    bootstrap('/not/this/module.js', 'file:///src/index.js', proc, makeTransport);
+    expect(makeTransport).not.toHaveBeenCalled();
+    expect(handlers).toEqual({});
+  });
+
+  it('runs main() when executed directly', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { proc, handlers, exited } = fakeProcess({ DATABASE_URL: 'postgres://u:p@h:5432/d' });
+    const [, serverTransport] = InMemoryTransport.createLinkedPair();
+    bootstrap('/app/index.js', 'file:///app/index.js', proc, () => serverTransport);
+    await vi.waitFor(() => expect(handlers.SIGINT).toBeDefined());
+    handlers.SIGINT();
+    await expect(exited).resolves.toBe(0);
+  });
+
+  it('logs a fatal error and exits 1 when startup fails (bad config)', async () => {
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { proc, exited } = fakeProcess({ PG_SSLMODE: 'verify_full' }); // typo -> loadConfig throws
+    const [, serverTransport] = InMemoryTransport.createLinkedPair();
+    bootstrap('/app/index.js', 'file:///app/index.js', proc, () => serverTransport);
+    await expect(exited).resolves.toBe(1);
+    expect(log).toHaveBeenCalledWith('[postgres-server] fatal:', expect.objectContaining({ message: expect.stringMatching(/unrecognized sslmode/) }));
+  });
+
+  it('the production transport factory builds a stdio transport (constructing it does not touch stdin)', () => {
+    expect(stdioTransport()).toBeInstanceOf(StdioServerTransport);
+  });
+});

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,0 +1,512 @@
+// Integration tests against a REAL Postgres via the MCP SDK client. Skipped unless PG_TEST_URL is set
+// (CI: postgres:16-alpine). Assert read-only holds: execute is gated, and every read runs in a
+// rolled-back BEGIN READ ONLY so a write hidden in a view/function/escaping fails with 25006. The
+// real boundary is the connecting role (see SECURITY.md).
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import pg from 'pg';
+import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { classifyPgError, createServer, defaultConnector, loadConfig, type Connector } from '../src/index.js';
+
+const PG_TEST_URL = process.env.PG_TEST_URL;
+const TABLE = 'mcp_v2_integration_test';
+const SEQ = 'mcp_v2_integration_test_seq';
+const READ_FUNCTION = 'mcp_v2_integration_hidden_write';
+const READ_VIEW = 'mcp_v2_integration_read_view';
+// A SELECT-only role, set up the way SECURITY.md tells users to - the
+// configuration the server is actually meant to run under.
+const RO_ROLE = 'mcp_v2_integration_readonly';
+const RO_PASSWORD = 'mcp_v2_integration_readonly';
+
+// PG_TEST_URL with a different login, for connecting as a specific role.
+function urlAs(user: string, password: string): string {
+  const url = new URL(PG_TEST_URL!);
+  url.username = user;
+  url.password = password;
+  return url.toString();
+}
+
+describe.skipIf(!PG_TEST_URL)('integration: real Postgres via PG_TEST_URL', () => {
+  let admin: pg.Client;
+  const spawned: pg.Client[] = [];
+
+  // Wrap the real connector so the test can track and close every connection the server opens.
+  const trackingConnector: Connector = {
+    async connect(cfg) {
+      const conn = await defaultConnector.connect(cfg);
+      spawned.push(conn.client);
+      return conn;
+    },
+  };
+
+  async function openServer(extraEnv: Record<string, string> = {}, databaseUrl = PG_TEST_URL) {
+    const config = loadConfig({ DATABASE_URL: databaseUrl, ...extraEnv });
+    const server = createServer(config, trackingConnector);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new McpClient({ name: 'integration-test', version: '0.0.0' });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    return {
+      client,
+      close: async () => {
+        await client.close();
+        await server.close();
+      },
+    };
+  }
+
+  function textOf(result: unknown): string {
+    const { content } = result as { content?: Array<{ type: string; text: string }> };
+    expect(content?.[0]?.type).toBe('text');
+    return content![0].text;
+  }
+
+  beforeAll(async () => {
+    admin = new pg.Client({ connectionString: PG_TEST_URL });
+    await admin.connect();
+    await admin.query(`DROP TABLE IF EXISTS ${TABLE}`);
+    await admin.query(`CREATE TABLE ${TABLE} (id int PRIMARY KEY, name text NOT NULL)`);
+    await admin.query(
+      `INSERT INTO ${TABLE} (id, name) VALUES (1, 'ada'), (2, 'brian'), (3, 'chandra')`
+    );
+    await admin.query(`DROP SEQUENCE IF EXISTS ${SEQ}`);
+    await admin.query(`CREATE SEQUENCE ${SEQ}`);
+    // A syntactically simple view read hides a write-capable function. It changes no rows.
+    await admin.query(`CREATE OR REPLACE FUNCTION ${READ_FUNCTION}() RETURNS int LANGUAGE plpgsql AS $$ BEGIN DELETE FROM ${TABLE} WHERE false; RETURN 42; END $$`);
+    await admin.query(`CREATE OR REPLACE VIEW ${READ_VIEW} AS SELECT ${READ_FUNCTION}() AS id`);
+
+    // The least-privilege role from SECURITY.md: CONNECT + USAGE + SELECT, nothing else.
+    await admin.query(`DROP OWNED BY ${RO_ROLE}`).catch(() => undefined); // role may not exist yet
+    await admin.query(`DROP ROLE IF EXISTS ${RO_ROLE}`);
+    await admin.query(`CREATE ROLE ${RO_ROLE} LOGIN PASSWORD '${RO_PASSWORD}'`);
+    const { rows } = await admin.query<{ db: string }>('SELECT current_database() AS db');
+    await admin.query(`GRANT CONNECT ON DATABASE "${rows[0].db}" TO ${RO_ROLE}`);
+    await admin.query(`GRANT USAGE ON SCHEMA public TO ${RO_ROLE}`);
+    await admin.query(`GRANT SELECT ON ${TABLE} TO ${RO_ROLE}`);
+  });
+
+  afterAll(async () => {
+    await admin.query(`DROP OWNED BY ${RO_ROLE}`); // revokes its grants so the role can go
+    await admin.query(`DROP ROLE IF EXISTS ${RO_ROLE}`);
+    await admin.query(`DROP VIEW IF EXISTS ${READ_VIEW}`);
+    await admin.query(`DROP FUNCTION IF EXISTS ${READ_FUNCTION}()`);
+    await admin.query(`DROP TABLE IF EXISTS ${TABLE}`);
+    await admin.query(`DROP SEQUENCE IF EXISTS ${SEQ}`);
+    await admin.end();
+  });
+
+  afterEach(async () => {
+    // End any pg clients the server spawned, whether or not the
+    // implementation closed them itself.
+    await Promise.allSettled(spawned.splice(0).map((c) => c.end()));
+  });
+
+  it('a view whose read hides a write is refused by the engine (25006)', async () => {
+    expect((await admin.query(`SELECT id FROM ${READ_VIEW}`)).rows).toEqual([{ id: 42 }]);
+    const { client, close } = await openServer();
+    try {
+      const result = await client.callTool({ name: 'query', arguments: { sql: `SELECT id FROM ${READ_VIEW}` } });
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(textOf(result)).code).toBe('25006');
+    } finally {
+      await close();
+    }
+  });
+
+  it('a write hidden by non-standard string escaping is still refused by the engine', async () => {
+    const url = new URL(PG_TEST_URL!);
+    url.searchParams.set('options', '-c standard_conforming_strings=off');
+    const { client, close } = await openServer({}, url.toString());
+    try {
+      // With standard_conforming_strings=off the backslash changes how the string parses,
+      // so on this backend the statement actually contains a nextval() call.
+      const sql = String.raw`SELECT '\' AS a, ', nextval($$${SEQ}$$) --' AS b`;
+      const result = await client.callTool({ name: 'query', arguments: { sql } });
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(textOf(result)).code).toBe('25006');
+    } finally {
+      await close();
+    }
+  });
+
+  it('binds parameters without interpreting their contents as SQL', async () => {
+    const { client, close } = await openServer();
+    try {
+      const value = "'; COMMIT; DELETE FROM users; --";
+      const result = await client.callTool({ name: 'query', arguments: { sql: 'SELECT $1 AS value', params: [value] } });
+      expect(result.isError).toBeFalsy();
+      expect(JSON.parse(textOf(result)).rows).toEqual([{ value }]);
+    } finally {
+      await close();
+    }
+  });
+
+  it('query tool returns rows as compact JSON with rowCount and truncated:false', async () => {
+    const { client, close } = await openServer();
+    try {
+      const result = await client.callTool({
+        name: 'query',
+        arguments: { sql: `SELECT id, name FROM ${TABLE} ORDER BY id` },
+      });
+      expect(result.isError).toBeFalsy();
+      const text = textOf(result);
+      expect(text).not.toContain('\n'); // compact JSON - no pretty-printing
+      const payload = JSON.parse(text);
+      expect(payload.rows).toEqual([
+        { id: 1, name: 'ada' },
+        { id: 2, name: 'brian' },
+        { id: 3, name: 'chandra' },
+      ]);
+      expect(payload.rowCount).toBe(3);
+      expect(payload.returnedRows).toBe(3);
+      expect(payload.truncated).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+
+  it('read-only config: execute is registered but refuses writes without touching the database', async () => {
+    const { client, close } = await openServer();
+    try {
+      const names = (await client.listTools()).tools.map((t) => t.name);
+      expect(names).toContain('execute'); // discoverable
+      expect(names).not.toContain('connect_db');
+
+      const before = (await admin.query(`SELECT count(*)::int AS n FROM ${TABLE}`)).rows[0].n;
+      const result = await client.callTool({
+        name: 'execute',
+        arguments: { sql: `INSERT INTO ${TABLE} (id, name) VALUES (99, 'mallory')` },
+      });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toMatch(/read-only|PG_ALLOW_WRITE/); // names the fix
+      // the write never ran - row count unchanged.
+      const after = (await admin.query(`SELECT count(*)::int AS n FROM ${TABLE}`)).rows[0].n;
+      expect(after).toBe(before);
+    } finally {
+      await close();
+    }
+  });
+
+  it("read-only config: a write smuggled through query is refused by the engine's read-only transaction", async () => {
+    const { client, close } = await openServer();
+    try {
+      const result = await client.callTool({
+        name: 'query',
+        arguments: { sql: `DELETE FROM ${TABLE}` },
+      });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toMatch(/delete|read-only/i);
+
+      // And the data is untouched.
+      const { rows } = await admin.query(`SELECT count(*)::int AS n FROM ${TABLE}`);
+      expect(rows[0].n).toBe(3);
+    } finally {
+      await close();
+    }
+  });
+
+  it('ENGINE layer: a read-only session rejects INSERT with SQLSTATE 25006', async () => {
+    // The real boundary: prove the engine itself refuses a write in a read-only
+    // transaction, independent of anything the server does client-side.
+    const raw = new pg.Client({ connectionString: PG_TEST_URL });
+    await raw.connect();
+    try {
+      await raw.query('SET default_transaction_read_only = on');
+      const err: unknown = await raw
+        .query(`INSERT INTO ${TABLE} (id, name) VALUES (99, 'mallory')`)
+        .then(() => null)
+        .catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      const pgErr = err as Error & { code?: string };
+      expect(pgErr.code).toBe('25006');
+      expect(pgErr.message).toMatch(/cannot execute INSERT in a read-only transaction/);
+
+      // ...and classifyPgError turns that engine error into the right hint.
+      expect(classifyPgError(pgErr).hint).toMatch(/PG_ALLOW_WRITE/);
+    } finally {
+      await raw.end();
+    }
+  });
+
+  it('the set_config() read-only bypass is neutralized by the rolled-back transaction', async () => {
+    // The historical bypass: SELECT set_config('default_transaction_read_only','off',false),
+    // then a second read that writes. Here set_config runs inside the per-query
+    // BEGIN READ ONLY and is reverted by ROLLBACK, so it never reaches the session,
+    // and each later query is its own read-only transaction anyway.
+    const { client, close } = await openServer();
+    try {
+      const bypass = await client.callTool({
+        name: 'query',
+        arguments: { sql: "SELECT set_config('default_transaction_read_only', 'off', false) AS v" },
+      });
+      expect(bypass.isError).toBeFalsy(); // it runs, but inside the rolled-back transaction
+
+      // A write via a volatile function is still refused by the engine.
+      const write = await client.callTool({
+        name: 'query',
+        arguments: { sql: `SELECT nextval('${SEQ}')` },
+      });
+      expect(write.isError).toBe(true);
+      expect(JSON.parse(textOf(write)).code).toBe('25006');
+    } finally {
+      await close();
+    }
+  });
+
+  it('a session setting changed inside a read query is reverted by the rollback', async () => {
+    const { client, close } = await openServer({ PG_STATEMENT_TIMEOUT: '4000' });
+    try {
+      const changed = await client.callTool({
+        name: 'query',
+        arguments: { sql: "SELECT set_config('statement_timeout', '0', false) AS v" },
+      });
+      expect(changed.isError).toBeFalsy();
+      const show = JSON.parse(
+        textOf(await client.callTool({ name: 'query', arguments: { sql: 'SHOW statement_timeout' } }))
+      );
+      expect(show.rows).toEqual([{ statement_timeout: '4s' }]); // reverted, not 0
+    } finally {
+      await close();
+    }
+  });
+
+  it('ENGINE layer: the extended protocol rejects multi-command strings outright', async () => {
+    // The tools send user SQL with queryMode:'extended', which is now the only
+    // multi-statement protection: Postgres itself refuses two commands in one call.
+    const raw = new pg.Client({ connectionString: PG_TEST_URL });
+    await raw.connect();
+    try {
+      const err: unknown = await raw
+        .query({ text: 'SELECT 1; SELECT 2', values: [], queryMode: 'extended' } as pg.QueryConfig)
+        .then(() => null)
+        .catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/cannot insert multiple commands/);
+    } finally {
+      await raw.end();
+    }
+  });
+
+  it('parallel first calls share ONE connection - no leaked client', async () => {
+    const { client, close } = await openServer();
+    try {
+      const [a, b] = await Promise.all([
+        client.callTool({ name: 'list_schemas', arguments: {} }),
+        client.callTool({ name: 'list_schemas', arguments: {} }),
+      ]);
+      expect(a.isError).toBeFalsy();
+      expect(b.isError).toBeFalsy();
+      expect(spawned).toHaveLength(1);
+    } finally {
+      await close();
+    }
+  });
+
+  it('size cap: a tiny PG_MAX_RESULT_BYTES truncates the result to fewer rows and says how to refine', async () => {
+    const { client, close } = await openServer({ PG_MAX_RESULT_BYTES: '20' });
+    try {
+      const result = await client.callTool({
+        name: 'query',
+        arguments: { sql: `SELECT id FROM ${TABLE} ORDER BY id` },
+      });
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(textOf(result));
+      expect(payload.rowCount).toBe(3);
+      expect(payload.returnedRows).toBeLessThan(3);
+      expect(payload.returnedRows).toBeGreaterThanOrEqual(1);
+      expect(payload.rows).toHaveLength(payload.returnedRows);
+      expect(payload.truncated).toBe(true);
+      expect(payload.hint).toMatch(/LIMIT|WHERE|columns/);
+    } finally {
+      await close();
+    }
+  });
+
+  it('size cap: a single row larger than the budget returns 0 rows with truncated:true (does not bypass)', async () => {
+    const { client, close } = await openServer({ PG_MAX_RESULT_BYTES: '100' });
+    try {
+      const result = await client.callTool({ name: 'query', arguments: { sql: "SELECT repeat('x', 5000) AS big" } });
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(textOf(result));
+      expect(payload.rowCount).toBe(1);
+      expect(payload.returnedRows).toBe(0);
+      expect(payload.rows).toEqual([]);
+      expect(payload.truncated).toBe(true);
+      expect(payload.hint).toMatch(/budget|columns/);
+    } finally {
+      await close();
+    }
+  });
+
+  it('bad SQL returns an isError result, not a thrown protocol error', async () => {
+    const { client, close } = await openServer();
+    try {
+      // If the server threw McpError here, callTool would REJECT and this
+      // await would throw - the assertion below proves it resolves instead
+      // (spec 2025-11-25 / SEP-1303: execution errors are results).
+      const result = await client.callTool({
+        name: 'query',
+        arguments: { sql: 'SELECT * FROM WHERE' },
+      });
+      expect(result.isError).toBe(true);
+      const payload = JSON.parse(textOf(result));
+      expect(payload.message).toMatch(/syntax/i);
+    } finally {
+      await close();
+    }
+  });
+
+  it('unknown relation returns isError with the list_tables hint (42P01)', async () => {
+    const { client, close } = await openServer();
+    try {
+      const result = await client.callTool({
+        name: 'query',
+        arguments: { sql: 'SELECT * FROM table_that_does_not_exist_xyz' },
+      });
+      expect(result.isError).toBe(true);
+      const payload = JSON.parse(textOf(result));
+      expect(payload.code).toBe('42P01');
+      expect(payload.hint).toMatch(/list_tables/);
+    } finally {
+      await close();
+    }
+  });
+
+  it('describe_table returns the typed column DTO', async () => {
+    const { client, close } = await openServer();
+    try {
+      const result = await client.callTool({
+        name: 'describe_table',
+        arguments: { table: TABLE },
+      });
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(textOf(result));
+      const idColumn = payload.columns.find(
+        (c: { column: string }) => c.column === 'id'
+      );
+      expect(idColumn).toMatchObject({ column: 'id', is_primary_key: true });
+      expect(idColumn).toHaveProperty('type');
+      expect(idColumn).toHaveProperty('nullable');
+      expect(idColumn).toHaveProperty('default');
+    } finally {
+      await close();
+    }
+  });
+
+  it('execute (write mode): runs INSERT and DELETE, returning rowCount and command', async () => {
+    const { client, close } = await openServer({ PG_ALLOW_WRITE: 'true' });
+    try {
+      const inserted = await client.callTool({
+        name: 'execute',
+        arguments: { sql: `INSERT INTO ${TABLE} (id, name) VALUES ($1, $2)`, params: [4, 'dana'] },
+      });
+      expect(inserted.isError).toBeFalsy();
+      expect(JSON.parse(textOf(inserted))).toEqual({ rowCount: 1, command: 'INSERT' });
+
+      const deleted = await client.callTool({
+        name: 'execute',
+        arguments: { sql: `DELETE FROM ${TABLE} WHERE id = 4` },
+      });
+      expect(JSON.parse(textOf(deleted))).toEqual({ rowCount: 1, command: 'DELETE' });
+    } finally {
+      await close();
+    }
+  });
+
+  it('list_schemas and list_tables: public by default, any schema on request', async () => {
+    const { client, close } = await openServer();
+    try {
+      const schemas = JSON.parse(textOf(await client.callTool({ name: 'list_schemas', arguments: {} })));
+      expect(schemas.schemas).toEqual(expect.arrayContaining(['public', 'pg_catalog']));
+
+      const byDefault = JSON.parse(textOf(await client.callTool({ name: 'list_tables', arguments: {} })));
+      expect(byDefault.tables).toContain(TABLE);
+
+      const catalog = JSON.parse(
+        textOf(await client.callTool({ name: 'list_tables', arguments: { schema: 'pg_catalog' } }))
+      );
+      expect(catalog.tables).toContain('pg_class');
+      expect(catalog.tables).not.toContain(TABLE);
+    } finally {
+      await close();
+    }
+  });
+
+  it('connect_db (runtime connect): swaps to a new target, and a failed swap leaves the old one working', async () => {
+    const target = new URL(PG_TEST_URL!);
+    const { client, close } = await openServer({ PG_ENABLE_RUNTIME_CONNECT: 'true' });
+    try {
+      const swapped = await client.callTool({
+        name: 'connect_db',
+        arguments: {
+          host: target.hostname,
+          port: Number(target.port || 5432),
+          user: RO_ROLE,
+          password: RO_PASSWORD,
+          database: target.pathname.slice(1),
+        },
+      });
+      expect(swapped.isError).toBeFalsy();
+      expect(JSON.parse(textOf(swapped))).toMatchObject({ host: target.hostname });
+
+      // The read-only role can read...
+      const rows = JSON.parse(textOf(await client.callTool({ name: 'query', arguments: { sql: `SELECT count(*)::int AS n FROM ${TABLE}` } })));
+      expect(rows.rows[0].n).toBe(3);
+
+      const failed = await client.callTool({
+        name: 'connect_db',
+        arguments: { host: target.hostname, port: Number(target.port || 5432), user: 'nobody', password: 'wrong', database: 'nope' },
+      });
+      expect(failed.isError).toBe(true);
+      expect(JSON.parse(textOf(failed)).code).toBe('28P01');
+
+      const still = JSON.parse(textOf(await client.callTool({ name: 'query', arguments: { sql: 'SELECT 1 AS ok' } })));
+      expect(still.rows[0].ok).toBe(1);
+    } finally {
+      await close();
+    }
+  });
+
+  it('describe_table finds the primary key as a SELECT-only role (information_schema hides constraints from it)', async () => {
+    // information_schema.table_constraints / key_column_usage only list
+    // constraints on tables the role has some NON-SELECT privilege on, so a
+    // least-privilege role - the recommended setup - would see every column
+    // as is_primary_key:false. Primary keys must come from pg_catalog.
+    const { client, close } = await openServer({}, urlAs(RO_ROLE, RO_PASSWORD));
+    try {
+      const result = await client.callTool({
+        name: 'describe_table',
+        arguments: { table: TABLE },
+      });
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(textOf(result));
+      const byName = Object.fromEntries(
+        payload.columns.map((c: { column: string; is_primary_key: boolean }) => [c.column, c.is_primary_key])
+      );
+      expect(byName).toEqual({ id: true, name: false });
+    } finally {
+      await close();
+    }
+  });
+
+  it('describe_table reports only key columns as PK, not an index INCLUDE column (review #8)', async () => {
+    const INCL = 'mcp_v2_include_pk_test';
+    await admin.query(`DROP TABLE IF EXISTS ${INCL}`);
+    // pg_index.indkey lists the INCLUDE column too; only conkey is the real PK.
+    await admin.query(`CREATE TABLE ${INCL} (id int, payload text, PRIMARY KEY (id) INCLUDE (payload))`);
+    await admin.query(`GRANT SELECT ON ${INCL} TO ${RO_ROLE}`);
+    const { client, close } = await openServer({}, urlAs(RO_ROLE, RO_PASSWORD));
+    try {
+      const payload = JSON.parse(
+        textOf(await client.callTool({ name: 'describe_table', arguments: { table: INCL } }))
+      );
+      const byName = Object.fromEntries(
+        payload.columns.map((c: { column: string; is_primary_key: boolean }) => [c.column, c.is_primary_key])
+      );
+      expect(byName).toEqual({ id: true, payload: false });
+    } finally {
+      await close();
+      await admin.query(`DROP TABLE IF EXISTS ${INCL}`);
+    }
+  });
+});

--- a/test/ssh-connector.test.ts
+++ b/test/ssh-connector.test.ts
@@ -1,0 +1,221 @@
+// SSH connector logic with injected fakes - no real bastion. Pure pieces (host-key verification, auth
+// config, TLS servername) plus the connect()/close() lifecycle via the deps seam; the real
+// socket<->ssh<->pg wiring is proven by the stand's SSH-bastion E2E.
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import type pg from 'pg';
+import { loadConfig, type SshConfig } from '../src/index.js';
+import {
+  buildHostVerifier,
+  buildSshConnectConfig,
+  createSshConnector,
+  defaultKeyPath,
+  sslForTunnel,
+  type SshClientLike,
+  type SshConnectorDeps,
+} from '../src/ssh-connector.js';
+
+const dir = mkdtempSync(join(tmpdir(), 'mcp-ssh-'));
+const KEY_PATH = join(dir, 'id_ed25519');
+writeFileSync(KEY_PATH, 'PRIVATE-KEY-BYTES');
+// A fake $HOME with a default key, for the "default keys" auth path.
+const HOME_WITH_KEY = join(dir, 'home');
+mkdirSync(join(HOME_WITH_KEY, '.ssh'), { recursive: true });
+writeFileSync(join(HOME_WITH_KEY, '.ssh', 'id_ed25519'), 'DEFAULT-KEY-BYTES');
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+// Minimal SSH config with host-key verification satisfied via a pinned fingerprint.
+const BASE: SshConfig = { host: 'bastion', port: 22, fingerprint: 'SHA256:x', keepaliveIntervalMs: 15000 };
+
+function makeSsh() {
+  const events: Record<string, Array<(...a: unknown[]) => void>> = {};
+  return {
+    ended: 0,
+    forwardOut: () => undefined,
+    end(): void {
+      this.ended++;
+      this.emit('close'); // a real ssh2 client emits 'close' after end(); teardown awaits it
+    },
+    on(event: string, cb: (...a: unknown[]) => void) {
+      (events[event] ??= []).push(cb);
+      return this;
+    },
+    emit(event: string, ...args: unknown[]): void {
+      (events[event] ?? []).forEach((cb) => cb(...args));
+    },
+    listeners: (event: string) => events[event] ?? [],
+  };
+}
+
+function makePg(opts: { connectError?: Error } = {}) {
+  return {
+    options: undefined as pg.ClientConfig | undefined,
+    connected: 0,
+    ended: 0,
+    async connect(): Promise<void> {
+      this.connected++;
+      if (opts.connectError) throw opts.connectError;
+    },
+    async end(): Promise<void> {
+      this.ended++;
+    },
+  };
+}
+
+function depsFor(ssh: ReturnType<typeof makeSsh>, client: ReturnType<typeof makePg>, openError?: Error): SshConnectorDeps {
+  return {
+    openSsh: async () => {
+      if (openError) throw openError;
+      return ssh as unknown as SshClientLike;
+    },
+    createPgClient: (options) => {
+      client.options = options;
+      return client as unknown as pg.Client;
+    },
+  };
+}
+
+describe('buildHostVerifier', () => {
+  const key = Buffer.from('the-host-key-blob');
+  const fp = createHash('sha256').update(key).digest('base64');
+
+  it('accepts a matching pinned fingerprint (with or without the SHA256: prefix and = padding)', () => {
+    expect(buildHostVerifier({ ...BASE, fingerprint: fp })(key)).toBe(true);
+    expect(buildHostVerifier({ ...BASE, fingerprint: `SHA256:${fp}` })(key)).toBe(true);
+  });
+
+  it('rejects a non-matching fingerprint', () => {
+    expect(buildHostVerifier({ ...BASE, fingerprint: 'deadbeef' })(key)).toBe(false);
+  });
+
+  it('fails closed when no fingerprint is configured (fingerprint is the only host-key mode)', () => {
+    expect(() => buildHostVerifier({ host: 'bastion', port: 22, keepaliveIntervalMs: 15000 })).toThrow(/host-key verification is required: set PG_SSH_FINGERPRINT/);
+  });
+});
+
+describe('buildSshConnectConfig', () => {
+  it('reads the private key and carries keepalive, readyTimeout, and the host verifier', () => {
+    const conf = buildSshConnectConfig({ ...BASE, user: 'jump', privateKeyPath: KEY_PATH, passphrase: 'pw' }, 9000);
+    expect(conf).toMatchObject({ host: 'bastion', port: 22, username: 'jump', readyTimeout: 9000, keepaliveInterval: 15000, keepaliveCountMax: 3, passphrase: 'pw' });
+    expect((conf.privateKey as Buffer).toString()).toBe('PRIVATE-KEY-BYTES');
+    expect(typeof conf.hostVerifier).toBe('function');
+  });
+
+  it('resolves agent="true" from SSH_AUTH_SOCK and throws if it is unset', () => {
+    expect(buildSshConnectConfig({ ...BASE, agent: 'true' }, 1000, { SSH_AUTH_SOCK: '/run/agent.sock' }).agent).toBe('/run/agent.sock');
+    expect(() => buildSshConnectConfig({ ...BASE, agent: 'true' }, 1000, {})).toThrow(/SSH_AUTH_SOCK/);
+  });
+
+  it('uses an explicit agent socket path (e.g. a Windows named pipe)', () => {
+    expect(buildSshConnectConfig({ ...BASE, agent: '\\\\.\\pipe\\openssh-ssh-agent' }, 1000, {}).agent).toBe('\\\\.\\pipe\\openssh-ssh-agent');
+  });
+
+  it('uses an explicit password, but a key or agent takes precedence over it', () => {
+    expect(buildSshConnectConfig({ ...BASE, password: 'pw' }, 1000, {}).password).toBe('pw');
+    const withKey = buildSshConnectConfig({ ...BASE, privateKeyPath: KEY_PATH, password: 'pw' }, 1000, {});
+    expect(withKey.password).toBeUndefined();
+    expect((withKey.privateKey as Buffer).toString()).toBe('PRIVATE-KEY-BYTES');
+  });
+
+  it('falls back to a running agent (SSH_AUTH_SOCK) when nothing explicit is configured', () => {
+    expect(buildSshConnectConfig({ ...BASE }, 1000, { SSH_AUTH_SOCK: '/run/user/agent.sock' }).agent).toBe('/run/user/agent.sock');
+  });
+
+  it('falls back to a default key file (~/.ssh/id_ed25519) when there is no agent', () => {
+    const conf = buildSshConnectConfig({ ...BASE }, 1000, { HOME: HOME_WITH_KEY });
+    expect((conf.privateKey as Buffer).toString()).toBe('DEFAULT-KEY-BYTES');
+  });
+
+  it('throws when no key, agent, default key, or SSH_AUTH_SOCK is available', () => {
+    expect(() => buildSshConnectConfig({ ...BASE }, 1000, { HOME: dir })).toThrow(/SSH authentication required/);
+  });
+});
+
+describe('defaultKeyPath', () => {
+  it('finds a default key under $HOME/.ssh', () => {
+    expect(defaultKeyPath({ HOME: HOME_WITH_KEY })).toBe(join(HOME_WITH_KEY, '.ssh', 'id_ed25519'));
+  });
+
+  it('falls back to %USERPROFILE% when HOME is unset (Windows)', () => {
+    expect(defaultKeyPath({ USERPROFILE: HOME_WITH_KEY })).toBe(join(HOME_WITH_KEY, '.ssh', 'id_ed25519'));
+  });
+
+  it('returns undefined when no home is set or no default key exists', () => {
+    expect(defaultKeyPath({})).toBeUndefined();
+    expect(defaultKeyPath({ HOME: dir })).toBeUndefined();
+  });
+});
+
+describe('sslForTunnel', () => {
+  it('preserves the original hostname as servername on an object ssl policy', () => {
+    expect(sslForTunnel({ rejectUnauthorized: false }, 'db.example.com')).toEqual({ ssl: { rejectUnauthorized: false, servername: 'db.example.com' } });
+  });
+
+  it('passes a boolean ssl through and maps undefined to no ssl option', () => {
+    expect(sslForTunnel(false, 'db')).toEqual({ ssl: false });
+    expect(sslForTunnel(undefined, 'db')).toEqual({});
+  });
+});
+
+describe('createSshConnector.connect', () => {
+  const cfg = () => loadConfig({ DATABASE_URL: 'postgres://u:p@db.example.com:5433/app' });
+  const ssh256 = { ...BASE, agent: '/tmp/a.sock' }; // valid auth + host verification, no file reads
+
+  it('returns an owned connection: pg connects through 127.0.0.1 with the original TLS servername', async () => {
+    const ssh = makeSsh();
+    const pgc = makePg();
+    const conn = await createSshConnector(ssh256, depsFor(ssh, pgc)).connect(loadConfig({ DATABASE_URL: 'postgres://u:p@db.example.com:5433/app?sslmode=verify-full', PG_SSL_CA: KEY_PATH }));
+    expect(pgc.connected).toBe(1);
+    expect(pgc.options).toMatchObject({ host: '127.0.0.1', user: 'u', database: 'app', pipeline: true });
+    expect(typeof pgc.options?.port).toBe('number');
+    expect((pgc.options?.ssl as { servername?: string }).servername).toBe('db.example.com');
+    expect(ssh.listeners('error').length).toBe(1); // tunnel-drop wiring in place
+    await conn.close();
+    await conn.close(); // idempotent
+    expect(pgc.ended).toBe(1);
+    expect(ssh.ended).toBe(1);
+  });
+
+  it('releases the SSH client when the PostgreSQL connect fails after the tunnel opened', async () => {
+    const ssh = makeSsh();
+    const pgc = makePg({ connectError: new Error('auth failed') });
+    await expect(createSshConnector(ssh256, depsFor(ssh, pgc)).connect(cfg())).rejects.toThrow('auth failed');
+    expect(ssh.ended).toBe(1);
+  });
+
+  it('propagates an SSH open failure (host-key rejection / handshake) and opens no pg client', async () => {
+    const ssh = makeSsh();
+    const pgc = makePg();
+    await expect(createSshConnector(ssh256, depsFor(ssh, pgc, new Error('handshake refused'))).connect(cfg())).rejects.toThrow('handshake refused');
+    expect(pgc.connected).toBe(0);
+  });
+
+  it('rejects before opening anything when host-key verification is not configured', async () => {
+    const ssh = makeSsh();
+    const pgc = makePg();
+    // No fingerprint -> fail closed at config build, before any socket or handshake.
+    const noVerify: SshConfig = { host: 'bastion', port: 22, agent: '/tmp/a.sock', keepaliveIntervalMs: 15000 };
+    await expect(createSshConnector(noVerify, depsFor(ssh, pgc)).connect(cfg())).rejects.toThrow(/host-key verification is required/);
+    expect(ssh.ended).toBe(0);
+    expect(pgc.connected).toBe(0);
+  });
+
+  it('preserves full pg options (application_name, options/search_path) across the tunnel', async () => {
+    const ssh = makeSsh();
+    const pgc = makePg();
+    await createSshConnector(ssh256, depsFor(ssh, pgc)).connect(loadConfig({ DATABASE_URL: 'postgres://u:p@db.example.com:5433/app?application_name=mcp&options=-c%20search_path%3Dapp' }));
+    expect(pgc.options).toMatchObject({ host: '127.0.0.1', database: 'app', application_name: 'mcp', options: '-c search_path=app' });
+  });
+
+  it('awaits a single teardown for concurrent close() calls (ssh and pg each end once)', async () => {
+    const ssh = makeSsh();
+    const pgc = makePg();
+    const conn = await createSshConnector(ssh256, depsFor(ssh, pgc)).connect(cfg());
+    await Promise.all([conn.close(), conn.close(), conn.close()]);
+    expect(ssh.ended).toBe(1);
+    expect(pgc.ended).toBe(1);
+  });
+});

--- a/test/toolsurface.test.ts
+++ b/test/toolsurface.test.ts
@@ -1,0 +1,103 @@
+// Tool-surface tests: what the model can see IS the security posture. execute is always registered
+// but refuses in read-only mode; connect_db only with PG_ENABLE_RUNTIME_CONNECT=true. The listTools()
+// snapshot is a diffable artifact. The connector throws: listing tools must never touch the database.
+import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer, loadConfig, type Connector, type ServerConfig } from '../src/index.js';
+
+const throwingConnector: Connector = {
+  connect: () => {
+    throw new Error('tool listing must not connect to the database');
+  },
+};
+
+async function listToolsFor(config: ServerConfig) {
+  const server = createServer(config, throwingConnector);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'toolsurface-test', version: '0.0.0' });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  try {
+    return await client.listTools();
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+const DEFAULT_SURFACE = ['describe_table', 'execute', 'list_schemas', 'list_tables', 'query'];
+const FULL_SURFACE = [
+  'connect_db',
+  'describe_table',
+  'execute',
+  'list_schemas',
+  'list_tables',
+  'query',
+];
+
+describe('tool surface (registration-time gating)', () => {
+  it('default config registers the read tools plus execute (discoverable, refuses writes) - no connect_db', async () => {
+    const { tools } = await listToolsFor(loadConfig({}));
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(DEFAULT_SURFACE);
+    expect(names).toContain('execute'); // present so writes are discoverable; refuses until PG_ALLOW_WRITE=true
+    expect(names).not.toContain('connect_db');
+  });
+
+  it('readOnly:false + allowRuntimeConnect:true registers all six tools', async () => {
+    const { tools } = await listToolsFor(
+      loadConfig({ PG_ALLOW_WRITE: 'true', PG_ENABLE_RUNTIME_CONNECT: 'true' })
+    );
+    expect(tools.map((t) => t.name).sort()).toEqual(FULL_SURFACE);
+  });
+
+  it('execute is always present; PG_ALLOW_WRITE changes its behavior, not the tool set', async () => {
+    const ro = (await listToolsFor(loadConfig({}))).tools.map((t) => t.name);
+    const rw = (await listToolsFor(loadConfig({ PG_ALLOW_WRITE: 'true' }))).tools.map((t) => t.name);
+    expect(ro).toContain('execute');
+    expect(rw).toContain('execute');
+    expect(rw).not.toContain('connect_db');
+  });
+
+  it('annotates tools honestly: query follows the mode, execute is destructive, connect_db is open-world', async () => {
+    const { tools } = await listToolsFor(
+      loadConfig({ PG_ALLOW_WRITE: 'true', PG_ENABLE_RUNTIME_CONNECT: 'true' })
+    );
+    const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
+
+    // Introspection tools are always read-only (fixed SQL).
+    for (const read of ['list_schemas', 'list_tables', 'describe_table']) {
+      expect(byName[read].annotations?.readOnlyHint, `${read}.readOnlyHint`).toBe(true);
+      expect(byName[read].annotations?.openWorldHint, `${read}.openWorldHint`).toBe(false);
+    }
+
+    // query is sent directly with PG_ALLOW_WRITE=true, so it can write - readOnlyHint must say so.
+    expect(byName.query.annotations?.readOnlyHint).toBe(false);
+    expect(byName.query.annotations?.openWorldHint).toBe(false);
+
+    expect(byName.execute.annotations?.readOnlyHint).toBe(false);
+    expect(byName.execute.annotations?.destructiveHint).toBe(true);
+    expect(byName.execute.annotations?.idempotentHint).toBe(false);
+    expect(byName.execute.annotations?.openWorldHint).toBe(false);
+
+    expect(byName.connect_db.annotations?.readOnlyHint).toBe(false);
+    expect(byName.connect_db.annotations?.openWorldHint).toBe(true);
+  });
+
+  it('query is read-only (readOnlyHint true) in the default read-only mode', async () => {
+    const { tools } = await listToolsFor(loadConfig({}));
+    const query = tools.find((t) => t.name === 'query');
+    expect(query?.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('read-only (default) tool surface matches the snapshot', async () => {
+    expect(await listToolsFor(loadConfig({}))).toMatchSnapshot();
+  });
+
+  it('full (write + runtime connect) tool surface matches the snapshot', async () => {
+    expect(
+      await listToolsFor(loadConfig({ PG_ALLOW_WRITE: 'true', PG_ENABLE_RUNTIME_CONNECT: 'true' }))
+    ).toMatchSnapshot();
+  });
+});

--- a/test/units.test.ts
+++ b/test/units.test.ts
@@ -1,0 +1,422 @@
+// Pure-function units: capBySize, classifyPgError, loadConfig, resolveClientOptions. Pin the
+// safe-by-default posture (read-only unless PG_ALLOW_WRITE, connect_db off unless PG_ENABLE_RUNTIME_CONNECT).
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { baseClientOptions, capBySize, classifyPgError, defaultClientFactory, loadConfig, resolveClientOptions } from '../src/index.js';
+
+describe('capBySize', () => {
+  it('keeps every row when the combined JSON size fits the budget', () => {
+    const rows = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    expect(capBySize(rows, 1000)).toEqual({ rows, truncated: false });
+  });
+
+  it('drops rows past the byte budget and flags truncation', () => {
+    const rows = [{ a: 'x'.repeat(50) }, { a: 'y'.repeat(50) }, { a: 'z'.repeat(50) }];
+    const { rows: kept, truncated } = capBySize(rows, 80);
+    expect(truncated).toBe(true);
+    expect(kept.length).toBe(1);
+  });
+
+  it('returns no rows (truncated) when not even the first row fits the budget', () => {
+    const rows = [{ a: 'x'.repeat(1000) }, { a: 'y' }];
+    expect(capBySize(rows, 10)).toEqual({ rows: [], truncated: true });
+  });
+
+  it('measures utf-8 bytes, not characters', () => {
+    const rows = [{ s: 'é'.repeat(20) }, { s: 'é'.repeat(20) }]; // a 2-byte UTF-8 char
+    expect(capBySize(rows, 45).truncated).toBe(true);
+  });
+
+  it('handles an empty result set', () => {
+    expect(capBySize([], 100)).toEqual({ rows: [], truncated: false });
+  });
+});
+
+describe('classifyPgError', () => {
+  const pgError = (message: string, code: string) =>
+    Object.assign(new Error(message), { code });
+
+  it.each([
+    ['28P01', 'password authentication failed for user "app"', /PG_USER|PG_PASSWORD/],
+    ['3D000', 'database "nope" does not exist', /PG_DATABASE/],
+    ['42P01', 'relation "userz" does not exist', /list_tables/],
+    ['42703', 'column "nmae" does not exist', /describe_table/],
+    ['57014', 'canceling statement due to statement timeout', /LIMIT/i],
+    ['25006', 'cannot execute INSERT in a read-only transaction', /PG_ALLOW_WRITE/],
+  ])('maps SQLSTATE %s to an actionable hint', (code, message, hintPattern) => {
+    const classified = classifyPgError(pgError(message, code));
+    expect(classified.message).toBe(message);
+    expect(classified.code).toBe(code);
+    expect(classified.hint).toMatch(hintPattern);
+  });
+
+  it.each(['ECONNREFUSED', 'ENOTFOUND'])(
+    'maps connection error %s to a host/port hint',
+    (code) => {
+      const classified = classifyPgError(pgError('connect failed', code));
+      expect(classified.hint).toMatch(/PG_HOST|PG_PORT|DATABASE_URL/);
+    }
+  );
+
+  it('returns message only for unknown SQLSTATE codes', () => {
+    const classified = classifyPgError(pgError('something odd', '99999'));
+    expect(classified.message).toBe('something odd');
+    expect(classified.hint).toBeUndefined();
+  });
+
+  it('copes with non-Error throwables', () => {
+    const classified = classifyPgError('kaboom');
+    expect(classified.message).toContain('kaboom');
+    expect(classified.hint).toBeUndefined();
+  });
+});
+
+describe('loadConfig', () => {
+  it('applies safe defaults: readOnly, 32 KiB result budget, 30s timeout, no runtime connect', () => {
+    const cfg = loadConfig({});
+    expect(cfg.readOnly).toBe(true);
+    expect(cfg.maxResultBytes).toBe(32768);
+    expect(cfg.statementTimeoutMs).toBe(30_000);
+    expect(cfg.allowRuntimeConnect).toBe(false);
+  });
+
+  it('prefers DATABASE_URL over PG_* variables', () => {
+    const url = 'postgres://u:p@url-host:5433/urldb';
+    const cfg = loadConfig({
+      DATABASE_URL: url,
+      PG_HOST: 'env-host',
+      PG_USER: 'env-user',
+      PG_PASSWORD: 'env-pass',
+      PG_DATABASE: 'envdb',
+    });
+    // connectionString set means the connection is built from the URL; the
+    // client factory must ignore the PG_* fields whenever it is present.
+    expect(cfg.connectionString).toBe(url);
+  });
+
+  it('falls back to PG_* variables when DATABASE_URL is absent', () => {
+    const cfg = loadConfig({
+      PG_HOST: 'localhost',
+      PG_PORT: '5433',
+      PG_USER: 'app',
+      PG_PASSWORD: 'secret',
+      PG_DATABASE: 'appdb',
+    });
+    expect(cfg.connectionString).toBeUndefined();
+    expect(cfg.host).toBe('localhost');
+    expect(cfg.port).toBe(5433); // parsed to a number
+    expect(cfg.user).toBe('app');
+    expect(cfg.password).toBe('secret');
+    expect(cfg.database).toBe('appdb');
+  });
+
+  it('PG_ALLOW_WRITE=true flips readOnly off - anything else stays read-only (fail closed)', () => {
+    expect(loadConfig({ PG_ALLOW_WRITE: 'true' }).readOnly).toBe(false);
+    expect(loadConfig({ PG_ALLOW_WRITE: '1' }).readOnly).toBe(true);
+    expect(loadConfig({ PG_ALLOW_WRITE: 'TRUE' }).readOnly).toBe(true);
+    expect(loadConfig({ PG_ALLOW_WRITE: '' }).readOnly).toBe(true);
+    expect(loadConfig({}).readOnly).toBe(true);
+  });
+
+  it('PG_ENABLE_RUNTIME_CONNECT=true enables connect_db registration', () => {
+    expect(loadConfig({ PG_ENABLE_RUNTIME_CONNECT: 'true' }).allowRuntimeConnect).toBe(true);
+    expect(loadConfig({ PG_ENABLE_RUNTIME_CONNECT: 'false' }).allowRuntimeConnect).toBe(false);
+  });
+
+  it('parses PG_MAX_RESULT_BYTES and PG_STATEMENT_TIMEOUT as numbers', () => {
+    const cfg = loadConfig({ PG_MAX_RESULT_BYTES: '8192', PG_STATEMENT_TIMEOUT: '5000' });
+    expect(cfg.maxResultBytes).toBe(8192);
+    expect(cfg.statementTimeoutMs).toBe(5000);
+  });
+
+  it('falls back to defaults for non-positive or junk PG_MAX_RESULT_BYTES / PG_STATEMENT_TIMEOUT', () => {
+    const cfg = loadConfig({ PG_MAX_RESULT_BYTES: '0', PG_STATEMENT_TIMEOUT: 'abc' });
+    expect(cfg.maxResultBytes).toBe(32768);
+    expect(cfg.statementTimeoutMs).toBe(30000);
+  });
+
+  it('parses PG_CONNECT_TIMEOUT, defaulting to 10000', () => {
+    expect(loadConfig({}).connectTimeoutMs).toBe(10000);
+    expect(loadConfig({ PG_CONNECT_TIMEOUT: '2500' }).connectTimeoutMs).toBe(2500);
+    expect(loadConfig({ PG_CONNECT_TIMEOUT: 'junk' }).connectTimeoutMs).toBe(10000);
+  });
+
+  describe('PG_PORT parsing', () => {
+    it('parses a valid port and leaves it undefined when unset or empty', () => {
+      expect(loadConfig({ PG_PORT: '6543' }).port).toBe(6543);
+      expect(loadConfig({}).port).toBeUndefined();
+      expect(loadConfig({ PG_PORT: '' }).port).toBeUndefined();
+    });
+
+    it('accepts the boundary ports 1 and 65535', () => {
+      expect(loadConfig({ PG_PORT: '1' }).port).toBe(1);
+      expect(loadConfig({ PG_PORT: '65535' }).port).toBe(65535);
+    });
+
+    it('falls back to 5432 for non-numeric junk (lenient, like 0.1.x)', () => {
+      expect(loadConfig({ PG_PORT: 'abc' }).port).toBe(5432);
+    });
+
+    it.each(['0', '-1', '65536', '54340000', '99999'])(
+      'throws for an out-of-range port %s instead of hanging a connection',
+      (port) => {
+        expect(() => loadConfig({ PG_PORT: port })).toThrow(/PG_PORT.*between 1 and 65535/);
+      }
+    );
+  });
+
+  describe('sslmode parsing', () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'mcp-pg-ssl-'));
+    afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+    it('PG_SSLMODE=disable yields no ssl', () => {
+      const cfg = loadConfig({ PG_HOST: 'h', PG_SSLMODE: 'disable' });
+      expect(cfg.ssl ?? false).toBe(false);
+    });
+
+    it('PG_SSLMODE=require encrypts without certificate verification (libpq semantics)', () => {
+      const cfg = loadConfig({ PG_HOST: 'h', PG_SSLMODE: 'require' });
+      expect(cfg.ssl).toEqual({ rejectUnauthorized: false });
+    });
+
+    it('PG_SSLMODE=verify-full verifies the server certificate with rejectUnauthorized pinned on', () => {
+      const cfg = loadConfig({ PG_HOST: 'h', PG_SSLMODE: 'verify-full' });
+      // Pinned explicitly (not left to Node's default) so an inherited NODE_TLS_REJECT_UNAUTHORIZED=0
+      // cannot silently disable verification.
+      expect(cfg.ssl).toEqual({ rejectUnauthorized: true });
+    });
+
+    it('PG_SSL_CA points at a CA file whose contents are loaded for pg/tls', () => {
+      const caPath = join(scratch, 'ca.pem');
+      const pem = '-----BEGIN CERTIFICATE-----\nMIIFakeTestCertificate\n-----END CERTIFICATE-----\n';
+      writeFileSync(caPath, pem);
+      const cfg = loadConfig({ PG_HOST: 'h', PG_SSLMODE: 'verify-full', PG_SSL_CA: caPath });
+      expect(typeof cfg.ssl).toBe('object');
+      const ssl = cfg.ssl as { ca?: string };
+      expect(ssl.ca).toContain('BEGIN CERTIFICATE');
+    });
+
+    it('derives ssl from sslmode in DATABASE_URL', () => {
+      const on = loadConfig({ DATABASE_URL: 'postgres://u:p@db.example.com:5432/app?sslmode=require' });
+      expect(on.ssl).toEqual({ rejectUnauthorized: false });
+
+      const off = loadConfig({ DATABASE_URL: 'postgres://u:p@db.example.com:5432/app?sslmode=disable' });
+      expect(off.ssl ?? false).toBe(false);
+    });
+
+    it('honours ssl=true|false and case-insensitive sslmode from the URL', () => {
+      // ?ssl=true means verified TLS (native pg default), not plaintext and not no-verify.
+      expect(loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/db?ssl=true' }).ssl).toEqual({ rejectUnauthorized: true });
+      expect(loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/db?ssl=0' }).ssl ?? false).toBe(false);
+      // sslmode wins over ssl, and the key is read case-insensitively.
+      expect(loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/db?SSLMODE=verify-full' }).ssl).toEqual({ rejectUnauthorized: true });
+      expect(loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/db?sslmode=verify-full&ssl=0' }).ssl).toEqual({ rejectUnauthorized: true });
+    });
+
+    it('strips ssl-affecting URL params (ssl, percent-encoded) so they cannot downgrade the policy', () => {
+      // ?sslmode=verify-full&ssl=0 would otherwise connect in plaintext.
+      const a = loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/db?sslmode=verify-full&ssl=0' });
+      expect(a.connectionString).toBe('postgres://u:p@h:5432/db');
+      expect(a.ssl).toEqual({ rejectUnauthorized: true });
+      // percent-encoded name is matched by its decoded form.
+      const b = loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/db?sslmode=require&%73sl=0' });
+      expect(b.connectionString).toBe('postgres://u:p@h:5432/db');
+      // sslcert/sslkey/sslrootcert are removed (URL certs unsupported; use PG_SSL_CA).
+      const c = loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/db?sslmode=require&sslrootcert=/x&sslcert=/y' });
+      expect(c.connectionString).toBe('postgres://u:p@h:5432/db');
+      // sslnegotiation=direct would otherwise make pg resolve ssl to bare `true`, dropping the CA object.
+      const d = loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/db?sslmode=verify-full&sslnegotiation=direct' });
+      expect(d.connectionString).toBe('postgres://u:p@h:5432/db');
+      expect(d.ssl).toEqual({ rejectUnauthorized: true });
+    });
+
+    it('strips sslmode from the connection string so pg URL parsing cannot override the ssl object', () => {
+      // pg gives parsed URL params precedence over an explicit ssl option:
+      // left in place, sslmode=require would flip to FULL certificate
+      // verification (and break the README RDS one-liner).
+      const bare = loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/db?sslmode=require' });
+      expect(bare.connectionString).toBe('postgres://u:p@h:5432/db');
+      expect(bare.ssl).toEqual({ rejectUnauthorized: false });
+
+      const mixed = loadConfig({
+        DATABASE_URL: 'postgres://u:p@h:5432/db?sslmode=require&application_name=mcp',
+      });
+      expect(mixed.connectionString).toBe('postgres://u:p@h:5432/db?application_name=mcp');
+    });
+
+    it('prefer and allow encrypt without verifying the certificate (allow is aliased to prefer)', () => {
+      expect(loadConfig({ PG_HOST: 'h', PG_SSLMODE: 'prefer' }).ssl).toEqual({ rejectUnauthorized: false });
+      expect(loadConfig({ PG_HOST: 'h', PG_SSLMODE: 'allow' }).ssl).toEqual({ rejectUnauthorized: false });
+    });
+
+    it('verify-ca with a CA verifies the chain but skips the hostname check (libpq)', () => {
+      const caPath = join(scratch, 'verifyca.pem');
+      writeFileSync(caPath, '-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----\n');
+      const ssl = loadConfig({ PG_HOST: 'h', PG_SSLMODE: 'verify-ca', PG_SSL_CA: caPath }).ssl as {
+        ca?: string;
+        checkServerIdentity?: unknown;
+      };
+      expect(ssl.ca).toContain('BEGIN CERTIFICATE');
+      expect(typeof ssl.checkServerIdentity).toBe('function'); // hostname check disabled, unlike verify-full
+      expect((ssl as { rejectUnauthorized?: boolean }).rejectUnauthorized).toBe(true); // pinned against a global bypass
+    });
+
+    it('verify-ca without a CA is refused (a CA is required to verify anything)', () => {
+      expect(() => loadConfig({ PG_HOST: 'h', PG_SSLMODE: 'verify-ca' })).toThrow();
+    });
+
+    it('throws on an unrecognized sslmode instead of silently connecting without TLS', () => {
+      expect(() => loadConfig({ PG_HOST: 'h', PG_SSLMODE: 'verify_full' })).toThrow(/unrecognized sslmode/);
+      expect(() => loadConfig({ DATABASE_URL: 'postgres://u:p@h/db?sslmode=requir' })).toThrow(
+        /unrecognized sslmode/
+      );
+    });
+
+    it('PG_SSL_CA alone implies verify-full (CA loaded, hostname still checked)', () => {
+      const caPath = join(scratch, 'implied-ca.pem');
+      writeFileSync(caPath, '-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----\n');
+      const ssl = loadConfig({ PG_HOST: 'h', PG_SSL_CA: caPath }).ssl as {
+        ca?: string;
+        checkServerIdentity?: unknown;
+      };
+      expect(ssl.ca).toContain('BEGIN CERTIFICATE');
+      expect(ssl.checkServerIdentity).toBeUndefined(); // verify-full keeps the hostname check
+    });
+  });
+});
+
+describe('loadConfig: SSH tunnel (PG_SSH_*)', () => {
+  it('leaves ssh undefined when PG_SSH_HOST is not set (direct connection)', () => {
+    expect(loadConfig({ DATABASE_URL: 'postgres://u:p@db/app' }).ssh).toBeUndefined();
+  });
+
+  it('enables the tunnel on PG_SSH_HOST alone, defaulting the port to 22', () => {
+    const { ssh } = loadConfig({ DATABASE_URL: 'postgres://u:p@db/app', PG_SSH_HOST: 'bastion' });
+    expect(ssh).toEqual({
+      host: 'bastion',
+      port: 22,
+      user: undefined,
+      privateKeyPath: undefined,
+      passphrase: undefined,
+      agent: undefined,
+      password: undefined,
+      fingerprint: undefined,
+      keepaliveIntervalMs: 15000,
+    });
+  });
+
+  it('maps every PG_SSH_* field', () => {
+    const { ssh } = loadConfig({
+      DATABASE_URL: 'postgres://u:p@db/app',
+      PG_SSH_HOST: 'bastion',
+      PG_SSH_PORT: '2222',
+      PG_SSH_USER: 'jump',
+      PG_SSH_PRIVATE_KEY: '/keys/id_ed25519',
+      PG_SSH_PASSPHRASE: 'secret',
+      PG_SSH_AGENT: 'true',
+      PG_SSH_PASSWORD: 'pw',
+      PG_SSH_FINGERPRINT: 'SHA256:abc',
+      PG_SSH_KEEPALIVE_INTERVAL: '30000',
+    });
+    expect(ssh).toEqual({
+      host: 'bastion',
+      port: 2222,
+      user: 'jump',
+      privateKeyPath: '/keys/id_ed25519',
+      passphrase: 'secret',
+      agent: 'true',
+      password: 'pw',
+      fingerprint: 'SHA256:abc',
+      keepaliveIntervalMs: 30000,
+    });
+  });
+
+  it('falls back to port 22 for junk PG_SSH_PORT and throws for an out-of-range one', () => {
+    expect(loadConfig({ PG_SSH_HOST: 'b', PG_SSH_PORT: 'abc' }).ssh?.port).toBe(22);
+    expect(() => loadConfig({ PG_SSH_HOST: 'b', PG_SSH_PORT: '70000' })).toThrow(/invalid PG_SSH_PORT/);
+  });
+});
+
+describe('baseClientOptions', () => {
+  it('carries the timeouts and pipeline flag, and includes ssl only when a policy is set', () => {
+    const withSsl = baseClientOptions(loadConfig({ DATABASE_URL: 'postgres://u:p@h/d?sslmode=require', PG_STATEMENT_TIMEOUT: '5000', PG_CONNECT_TIMEOUT: '3000' }));
+    expect(withSsl).toMatchObject({ connectionTimeoutMillis: 3000, query_timeout: 8000, pipeline: true, ssl: { rejectUnauthorized: false } });
+    const noSsl = baseClientOptions(loadConfig({ DATABASE_URL: 'postgres://u:p@h/d' }));
+    expect('ssl' in noSsl).toBe(false);
+  });
+});
+
+describe('resolveClientOptions', () => {
+  it('preserves full connection-string settings (application_name, options/search_path) and applies ssl', () => {
+    const opts = resolveClientOptions(loadConfig({ DATABASE_URL: 'postgres://u:p@db.example.com:5433/app?application_name=mcp&options=-c%20search_path%3Dapp&sslmode=require' }));
+    expect(opts).toMatchObject({
+      host: 'db.example.com',
+      port: 5433,
+      user: 'u',
+      password: 'p',
+      database: 'app',
+      application_name: 'mcp',
+      options: '-c search_path=app',
+      pipeline: true,
+      ssl: { rejectUnauthorized: false },
+    });
+  });
+
+  it('uses the PG_* fields when there is no connection string', () => {
+    const opts = resolveClientOptions(loadConfig({ PG_HOST: 'h', PG_PORT: '6543', PG_USER: 'x', PG_PASSWORD: 'y', PG_DATABASE: 'd' }));
+    expect(opts).toMatchObject({ host: 'h', port: 6543, user: 'x', database: 'd' });
+  });
+
+  it('strips the brackets pg-connection-string keeps on an IPv6 literal so pg can resolve it', () => {
+    expect(resolveClientOptions(loadConfig({ DATABASE_URL: 'postgres://u:p@[::1]:5434/db' })).host).toBe('::1');
+    // A bracketed non-IP token is left untouched (only real IPv6 literals are unwrapped).
+    expect(resolveClientOptions({ ...loadConfig({}), host: '[not-an-ip]' }).host).toBe('[not-an-ip]');
+    // A plain hostname passes through, and an absent host stays undefined.
+    expect(resolveClientOptions(loadConfig({ PG_HOST: 'plain.example' })).host).toBe('plain.example');
+    expect(resolveClientOptions(loadConfig({ PG_USER: 'u' })).host).toBeUndefined();
+  });
+
+  it('rejects an out-of-range port (URL ?port= included) before any connect', () => {
+    expect(() => resolveClientOptions(loadConfig({ DATABASE_URL: 'postgres://u:p@127.0.0.1/db?port=999999' }))).toThrow(/invalid port/);
+  });
+});
+
+describe('defaultClientFactory', () => {
+  // pg.Client exposes what it parsed as connectionParameters; nothing connects here.
+  const paramsOf = (cfg: Parameters<typeof defaultClientFactory>[0]) =>
+    (defaultClientFactory(cfg) as unknown as { connectionParameters: Record<string, unknown> }).connectionParameters;
+
+  it('prefers the connection string and passes the ssl policy alongside it', () => {
+    const cfg = loadConfig({ DATABASE_URL: 'postgres://u:p@db.example.com:5433/app?sslmode=require' });
+    const params = paramsOf(cfg);
+    expect(params).toMatchObject({ host: 'db.example.com', port: 5433, user: 'u', database: 'app' });
+    expect(params.ssl).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('falls back to the PG_* fields, leaving ssl to pg defaults when no policy is set', () => {
+    const cfg = loadConfig({ PG_HOST: 'h', PG_PORT: '6543', PG_USER: 'u', PG_PASSWORD: 'p', PG_DATABASE: 'd' });
+    const params = paramsOf(cfg);
+    expect(params).toMatchObject({ host: 'h', port: 6543, user: 'u', database: 'd' });
+    expect(params.ssl).toBeFalsy();
+  });
+
+  it('passes connectionTimeoutMillis so a stalled connect cannot hang forever', () => {
+    const client = defaultClientFactory(loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/d', PG_CONNECT_TIMEOUT: '3000' }));
+    expect((client as unknown as { _connectionTimeoutMillis: number })._connectionTimeoutMillis).toBe(3000);
+  });
+
+  it('sets query_timeout above statement_timeout as a client-side deadline for a stalled socket', () => {
+    // server-side statement_timeout cannot fire when the server never answers; query_timeout can.
+    const client = defaultClientFactory(
+      loadConfig({ DATABASE_URL: 'postgres://u:p@h:5432/d', PG_STATEMENT_TIMEOUT: '5000', PG_CONNECT_TIMEOUT: '3000' })
+    );
+    expect((client as unknown as { connectionParameters: { query_timeout: number } }).connectionParameters.query_timeout).toBe(8000);
+  });
+
+  it('throws for a DATABASE_URL ?port= outside 1-65535, before any connect (no ERR_SOCKET_BAD_PORT crash)', () => {
+    // pg parses ?port= into connectionParameters.port, bypassing PG_PORT/connect_db checks.
+    expect(() => defaultClientFactory(loadConfig({ DATABASE_URL: 'postgres://u:p@127.0.0.1/db?port=999999' }))).toThrow(/invalid port/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    // Integration tests talk to a real Postgres (PG_TEST_URL); give them headroom.
+    testTimeout: 15_000,
+    hookTimeout: 15_000,
+    coverage: {
+      provider: 'v8',
+      include: ['src/**'],
+      // ssh-connector is I/O glue (sockets, ssh2 forwarding, pg over a tunnel): its logic is unit-tested
+      // with injected fakes and its real wiring is proven by the stand's SSH-bastion E2E, neither of which
+      // a coverage % would capture. Excluded so it does not force over-mocked tests onto the core's bar.
+      exclude: ['src/ssh-connector.ts'],
+      // 100% is the bar for the core, and CI enforces it. Run with PG_TEST_URL set: the
+      // integration suite covers the paths that only a real engine exercises.
+      thresholds: { lines: 100, functions: 100, branches: 100, statements: 100 },
+    },
+  },
+});


### PR DESCRIPTION
Read-only by default, optional SSH tunneling, and byte-capped query results.

## Breaking changes
- **Read-only by default.** Writes require `PG_ALLOW_WRITE=true`; `execute` stays visible but refuses them until then.
- **`connect_db` opt-in** via `PG_ENABLE_RUNTIME_CONNECT=true` (otherwise not registered).
- **New result shapes** (compact JSON): `query` → `{rows, rowCount, returnedRows, truncated}`; `list_schemas`/`list_tables`/`describe_table` restructured.

## Highlights
- Engine-enforced read-only: `BEGIN READ ONLY` + bound statement + `ROLLBACK` (2 round-trips, no client-side SQL parser — PostgreSQL is the boundary).
- Optional SSH tunneling (`PG_SSH_*`): self-contained connector loaded only when configured; mandatory host-key pinning (fail-closed); key / agent / password auth with `ssh`-style fallback; TLS validated against the real hostname; keepalive + lazy reconnect. `ssh2` is an optional dependency.
- `DATABASE_URL` support, `PG_SSLMODE`/`PG_SSL_CA`, IPv6 URLs, full pg options.
- Result size cap (`PG_MAX_RESULT_BYTES`, default 32768): whole rows within the byte budget, else `truncated: true` + a refine hint.
- Statement/connect timeouts, SQLSTATE-based error hints, superuser warning.
- Failures returned as `isError: true` tool results instead of thrown protocol errors.

## Testing
- Build green; 154 tests; 100% coverage on `src/index.ts`.
- Unit + integration (real Postgres) + tool-surface snapshot; CI on Node 20/22/24.

See `CHANGELOG.md` and the "Migrating from 0.1.x" section in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmJX1haar3VYyEgBYCu8Vt